### PR TITLE
Add an API to query for sources associated with the embedded artifacts of a build

### DIFF
--- a/assayist/client/__init__.py
+++ b/assayist/client/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-3.0+

--- a/assayist/client/error.py
+++ b/assayist/client/error.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+
+class NotFound(RuntimeError):
+    """Signify that a node was not found in the database."""
+
+    pass

--- a/assayist/client/query.py
+++ b/assayist/client/query.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+import neomodel
+
+from assayist.common.models.content import Build
+from assayist.client.error import NotFound
+
+
+def set_connection(neo4j_url):
+    """
+    Set the Neo4j connection string.
+
+    :param str neo4j_url: the Neo4j connection string to configure neomodel with
+    """
+    neomodel.db.set_connection(neo4j_url)
+
+
+def get_container_content_sources(build_id):
+    """
+    Get the sources used by the content in the container image.
+
+    :param int build_id: the Koji build's ID
+    :return: a list of source URLs
+    :rtype: list
+    """
+    build = Build.nodes.get_or_none(id_=str(build_id))
+    if not build:
+        raise NotFound('The requested build does not exist in the database')
+
+    # Bypass neomodel and use cypher directly for better performance
+    internal_query = """
+        MATCH (:Build {{id: '{0}'}})-[:PRODUCED]->(:Artifact)-[:EMBEDS]-(:Artifact)
+            <-[:PRODUCED]-(:Build)-[:BUILT_FROM]->(internal:SourceLocation)
+        OPTIONAL MATCH (internal)-[:UPSTREAM]->(upstream:SourceLocation)
+        RETURN internal.url, upstream.url;
+    """.format(build_id)
+    results, _ = neomodel.db.cypher_query(internal_query)
+    internal_urls = []
+    upstream_urls = []
+    for result in results:
+        internal_urls.append(result[0])
+        upstream_urls.append(result[1])
+    return {
+        'internal_urls': internal_urls,
+        'upstream_urls': upstream_urls
+    }

--- a/assayist/common/models/content.py
+++ b/assayist/common/models/content.py
@@ -26,7 +26,7 @@ class Build(AssayistStructuredNode):
     # The artifacts that were produced by this build
     artifacts = RelationshipTo('Artifact', 'PRODUCED')
     # The source location used for this build
-    source = RelationshipTo('.source.SourceLocation', 'BUILT_FROM', cardinality=ZeroOrOne)
+    source_location = RelationshipTo('.source.SourceLocation', 'BUILT_FROM', cardinality=ZeroOrOne)
 
 
 class Artifact(AssayistStructuredNode):

--- a/assayist/common/models/source.py
+++ b/assayist/common/models/source.py
@@ -48,3 +48,7 @@ class SourceLocation(AssayistStructuredNode):
     embedded_source_locations = RelationshipTo('SourceLocation', 'EMBEDS')
     # Source locations this source location is embedded in
     source_locations_embedded_in = RelationshipFrom('SourceLocation', 'EMBEDS')
+    # The upstream source location for this source location (applies to internal only)
+    upstream = RelationshipTo('SourceLocation', 'UPSTREAM')
+    # The source locations this source location is the upstream for
+    upstream_for = RelationshipFrom('SourceLocation', 'UPSTREAM')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     packages=[
         'assayist',
         'assayist.common',
-        'assayist.processor'
+        'assayist.processor',
+        'assayist.client'
     ],
     include_package_data=True,
     install_requires=requirements,

--- a/tests/client/test_query.py
+++ b/tests/client/test_query.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+from assayist.client import query
+from assayist.common.models.content import Build, Artifact
+from assayist.common.models.source import SourceLocation
+
+
+def test_get_container_sources():
+    """Test the get_container_sources function."""
+    # Create the container build entry
+    container_build_id = '742663'
+    container_build = Build(id_=container_build_id, type='container').save()
+    container_filename = ('docker-image-sha256:98217b7c89052267e1ed02a41217c2e03577b96125e923e9594'
+                          '1ac010f209ee6.x86_64.tar.gz')
+    container_artifact = Artifact(
+        archive_id='742663', architecture='x86_64', filename=container_filename).save()
+    container_build.artifacts.connect(container_artifact)
+    container_internal_url = ('git://pks.domain.local/containers/etcd#'
+                              '3dcd6fc75e674589ac7d2294dbf79bd8ebd459fb')
+    container_internal_source = SourceLocation(url=container_internal_url).save()
+    container_build.source_location.connect(container_internal_source)
+
+    # Create the embedded artifacts
+    etcd_build = Build(id_='770188', type='rpm').save()
+    etcd_rpm = Artifact(
+        archive_id='5818103', architecture='x86_64', filename='etcd-3.2.22-1.el7.x86_64.rpm').save()
+    etcd_build.artifacts.connect(etcd_rpm)
+    etcd_upstream_url = ('https://github.com/coreos/etcd/archive/1674e682fe9fbecd66e9f20b77da852ad7'
+                         'f517a9/etcd-1674e682.tar.gz')
+    etcd_upstream_source = SourceLocation(url=etcd_upstream_url).save()
+    etcd_internal_url = 'git://pks.domain.local/rpms/etcd#84858fb38a89e1177b0303c675d206f90f6a83e2'
+    etcd_internal_source = SourceLocation(url=etcd_internal_url).save()
+    etcd_build.source_location.connect(etcd_internal_source)
+    etcd_internal_source.upstream.connect(etcd_upstream_source)
+    container_artifact.embedded_artifacts.connect(etcd_rpm)
+
+    yum_utils_build = Build(id_='728353', type='rpm').save()
+    yum_utils_rpm = Artifact(
+        archive_id='5962202', architecture='x86_64',
+        filename='yum-utils-1.1.31-46.el7_5.noarch.rpm').save()
+    yum_utils_build.artifacts.connect(yum_utils_rpm)
+    yum_utils_upstream_url = 'http://yum.baseurl.org/download/yum-utils/yum-utils-1.1.31.tar.gz'
+    yum_utils_upstream_source = SourceLocation(url=yum_utils_upstream_url).save()
+    yum_utils_internal_url = ('git://pks.domain.local/rpms/yum-utils#562e476db1be88f58662d6eb3'
+                              '82bb37e87bf5824')
+    yum_utils_internal_source = SourceLocation(url=yum_utils_internal_url).save()
+    yum_utils_build.source_location.connect(yum_utils_internal_source)
+    yum_utils_internal_source.upstream.connect(yum_utils_upstream_source)
+    container_artifact.embedded_artifacts.connect(yum_utils_rpm)
+
+    expected = {
+        'internal_urls': [yum_utils_internal_url, etcd_internal_url],
+        'upstream_urls': [yum_utils_upstream_url, etcd_upstream_url]
+    }
+    assert query.get_container_content_sources(container_build_id) == expected


### PR DESCRIPTION
As part of this PR, I also fixed a relationship name (`source` => `source_location`) to not shadow a neomodel property, and I added an "upstream" relationship to source locations as discussed with @jdcasey  in IRC.