### PR TITLE
Nitpicky change of `type` to `type_` to not shadow a Python built-in

### DIFF
--- a/assayist/common/models/content.py
+++ b/assayist/common/models/content.py
@@ -20,7 +20,7 @@ class Build(AssayistStructuredNode):
     # Call it "id_" to not overshadow the Neo4j internal ID used by neomodel, but call
     # it "id" in Neo4j
     id_ = StringProperty(db_property='id', required=True, unique_index=True)
-    type = StringProperty()
+    type_ = StringProperty()
 
     # The artifacts that were produced by this build
     artifacts = RelationshipTo('Artifact', 'PRODUCED')
@@ -40,7 +40,7 @@ class Artifact(AssayistStructuredNode):
     archive_id = StringProperty(required=True, unique_index=True)
     filename = StringProperty()
     # A one-word description of the type of file this describes (to aid in filtering)
-    type = StringProperty(required=True)
+    type_ = StringProperty(required=True)
 
     # The artifacts this artifact is embedded in
     artifacts_embedded_in = RelationshipFrom('Artifact', 'EMBEDS')
@@ -71,7 +71,7 @@ class ExternalArtifact(AssayistStructuredNode):
     """
 
     identifier = StringProperty(unique_index=True)
-    type = StringProperty(index=True)
+    type_ = StringProperty(index=True)
 
     # The artifacts that used this external artifact in their buildroot
     artifacts_in_buildroot_for = RelationshipFrom('Artifact', 'BUILT_WITH')

--- a/tests/client/test_query.py
+++ b/tests/client/test_query.py
@@ -9,12 +9,12 @@ def test_get_container_sources():
     """Test the get_container_sources function."""
     # Create the container build entry
     container_build_id = '742663'
-    container_build = Build(id_=container_build_id, type='container').save()
+    container_build = Build(id_=container_build_id, type_='container').save()
     container_filename = ('docker-image-sha256:98217b7c89052267e1ed02a41217c2e03577b96125e923e9594'
                           '1ac010f209ee6.x86_64.tar.gz')
     container_artifact = Artifact(
         archive_id='742663', architecture='x86_64', filename=container_filename,
-        type='container').save()
+        type_='container').save()
     container_build.artifacts.connect(container_artifact)
     container_internal_url = ('git://pks.domain.local/containers/etcd#'
                               '3dcd6fc75e674589ac7d2294dbf79bd8ebd459fb')
@@ -22,10 +22,10 @@ def test_get_container_sources():
     container_build.source_location.connect(container_internal_source)
 
     # Create the embedded artifacts
-    etcd_build = Build(id_='770188', type='rpm').save()
+    etcd_build = Build(id_='770188', type_='rpm').save()
     etcd_rpm = Artifact(
         archive_id='5818103', architecture='x86_64', filename='etcd-3.2.22-1.el7.x86_64.rpm',
-        type='rpm').save()
+        type_='rpm').save()
     etcd_build.artifacts.connect(etcd_rpm)
     etcd_upstream_url = ('https://github.com/coreos/etcd/archive/1674e682fe9fbecd66e9f20b77da852ad7'
                          'f517a9/etcd-1674e682.tar.gz')
@@ -36,9 +36,9 @@ def test_get_container_sources():
     etcd_internal_source.upstream.connect(etcd_upstream_source)
     container_artifact.embedded_artifacts.connect(etcd_rpm)
 
-    yum_utils_build = Build(id_='728353', type='rpm').save()
+    yum_utils_build = Build(id_='728353', type_='rpm').save()
     yum_utils_rpm = Artifact(
-        archive_id='5962202', architecture='x86_64', type='rpm',
+        archive_id='5962202', architecture='x86_64', type_='rpm',
         filename='yum-utils-1.1.31-46.el7_5.noarch.rpm').save()
     yum_utils_build.artifacts.connect(yum_utils_rpm)
     yum_utils_upstream_url = 'http://yum.baseurl.org/download/yum-utils/yum-utils-1.1.31.tar.gz'


### PR DESCRIPTION
Main reason is to not "break" syntax highlighting in code editors.