### PR TITLE
Use type on Neo4j properties but continue using type_ in Python

### DIFF
--- a/assayist/common/models/content.py
+++ b/assayist/common/models/content.py
@@ -20,7 +20,7 @@ class Build(AssayistStructuredNode):
     # Call it "id_" to not overshadow the Neo4j internal ID used by neomodel, but call
     # it "id" in Neo4j
     id_ = StringProperty(db_property='id', required=True, unique_index=True)
-    type_ = StringProperty()
+    type_ = StringProperty(db_property='type')
 
     # The artifacts that were produced by this build
     artifacts = RelationshipTo('Artifact', 'PRODUCED')
@@ -40,7 +40,7 @@ class Artifact(AssayistStructuredNode):
     archive_id = StringProperty(required=True, unique_index=True)
     filename = StringProperty()
     # A one-word description of the type of file this describes (to aid in filtering)
-    type_ = StringProperty(required=True)
+    type_ = StringProperty(required=True, db_property='type')
 
     # The artifacts this artifact is embedded in
     artifacts_embedded_in = RelationshipFrom('Artifact', 'EMBEDS')
@@ -73,7 +73,7 @@ class ExternalArtifact(AssayistStructuredNode):
     """
 
     identifier = StringProperty(unique_index=True)
-    type_ = StringProperty(index=True)
+    type_ = StringProperty(index=True, db_property='type')
 
     # The artifacts that used this external artifact in their buildroot
     artifacts_in_buildroot_for = RelationshipFrom('Artifact', 'BUILT_WITH')


### PR DESCRIPTION
This change makes it so that the `type_` property is called in `type` in Neo4j since an underscore is ugly and not necessary there.