### PR TITLE
Add APIs to find container builds affected by buildroots containing a specific component

### DIFF
--- a/assayist/client/error.py
+++ b/assayist/client/error.py
@@ -5,3 +5,9 @@ class NotFound(RuntimeError):
     """Signify that a node was not found in the database."""
 
     pass
+
+
+class InvalidInput(RuntimeError):
+    """Signify that the input to the API was invalid."""
+
+    pass

--- a/assayist/client/query.py
+++ b/assayist/client/query.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0+
 
+import collections
+
 import neomodel
 
 from assayist.common.models.content import Artifact, Build
 from assayist.common.models.source import Component, SourceLocation
-from assayist.client.error import NotFound
+from assayist.client.error import NotFound, InvalidInput
 
 
 def set_connection(neo4j_url):
@@ -178,3 +180,114 @@ def get_source_components_for_build(build_id):
         artifacts[aid] = construct(aid)
 
     return artifacts
+
+
+def get_current_and_previous_versions(name, type_, version):
+    """
+    Find the current and previous source locations.
+
+    :param str name: the canonical name of the component
+    :param str type_: the canonical type of the component
+    :param str version: the canonical version of the source location
+    :return: a dictionary of all the previous source locations and the current source location
+    :rtype: dict
+    """
+    # TODO: Consider alternative names as well
+    query = """
+        MATCH (:Component {{canonical_name: '{name}', canonical_type: '{type}'}})
+            <-[:SOURCE_FOR]-(:SourceLocation {{canonical_version: '{version}'}})
+            -[:SUPERSEDES*0..]->(sl:SourceLocation)
+        RETURN sl
+    """.format(name=name, type=type_, version=version)
+    results, _ = neomodel.db.cypher_query(query)
+    rv = []
+    for result in results:
+        rv.append(dict(result[0]))
+    return rv
+
+
+def get_container_built_with_sources(source_locations):
+    """
+    Match container builds that used the input source locations to build the content in the image.
+
+    This means any container that:
+    * embeds artifacts that were built with artifacts built from the input and related source
+      locations
+    * was built with a container that embeds artifacts that were built with the input and related
+      source locations
+
+    :param list source_locations: a list of source location dictionaries to match against
+    :return: a list of affected container build Koji IDs
+    :rtype: list
+    """
+    if not source_locations or not isinstance(source_locations, collections.Iterable):
+        raise InvalidInput('The input must be a list of source locations')
+
+    # Get all the input source locations, then find the upstream or downstream source locations.
+    # With that result, find all the source locations that embed the resulting source locations.
+    # Then return the Neo4j IDs of the union of all the source locations in the query.
+    query = """
+    // First get all the input source locations
+    MATCH (input_sl:SourceLocation) WHERE input_sl.url IN [{0}]
+    // Then find all the source locations that are upstream or downstream of the input source
+    // locations recursively. The resulting `input_and_upstream_sl` variable has all the input
+    // source locations and all the upstream or downstream source locations of the input source
+    // locations.
+    MATCH (input_sl)-[:UPSTREAM*0..]-(input_and_upstream_sl:SourceLocation)
+    // Then find all the source locations that embed the source locations in
+    // `input_and_upstream_sl` recursively. The resulting `input_upstream_and_embedded_sl`
+    // variable will have the contents of the `input_and_upstream_sl` variable previously and
+    // all the source locations that eventually embed those source locations.
+    MATCH (input_and_upstream_sl)<-[:EMBEDS*0..]-(input_upstream_and_embedded_sl:SourceLocation)
+    RETURN ID(input_upstream_and_embedded_sl)
+    """.format(', '.join(repr(sl['url']) for sl in source_locations if 'url' in sl))
+    results, _ = neomodel.db.cypher_query(query)
+    # This should only be true if none of the input source locations are in the DB
+    if not results:
+        return []
+    all_sl_ids = set([r[0] for r in results])
+
+    # Find all the artifacts that were built from the source locations, and those that embed them.
+    # Then return the Neo4j IDs of the resulting artifacts.
+    query = """
+    // First get all the input source locations
+    MATCH (sl) WHERE ID(sl) IN [{0}]
+    // Find all the artifacts that were built from the source locations, and all the artifacts that
+    // embed those artifacts
+    MATCH (sl)<-[:BUILT_FROM]-(:Build)-[:PRODUCED]->(:Artifact)<-[:EMBEDS*0..]-(artifact:Artifact)
+    RETURN ID(artifact)
+    """.format(', '.join(str(sl_id) for sl_id in all_sl_ids))
+    results, _ = neomodel.db.cypher_query(query)
+    affected_artifact_ids = set([r[0] for r in results])
+
+    # Find all the builds of container artifacts that were built with any of the containers in
+    # affected_artifact_ids
+    query = """
+    // First get all the directly affected container artifacts
+    MATCH (affected_container) WHERE ID(affected_container) IN [{0}]
+        AND affected_container.type = 'container'
+    // Find all the builds of container artifacts that that were built with any of the affected
+    // container artifacts
+    MATCH (affected_container)<-[:BUILT_WITH]-(:Artifact {{type: 'container'}})
+        <-[:PRODUCED]-(built_with_affected_container:Build)
+    RETURN built_with_affected_container.id
+    """.format(', '.join(repr(artifact_id) for artifact_id in affected_artifact_ids))
+    results, _ = neomodel.db.cypher_query(query)
+    builds_built_with_affected_container = set([r[0] for r in results])
+
+    # Find all the builds of the container artifacts that embed an artifact that was built with any
+    # of the artifacts in affected_artifact_ids
+    query = """
+    // First get all the artifacts that were built from the source locations
+    MATCH (artifact) WHERE ID(artifact) IN [{0}]
+    // Find all the container image builds that embed an artifact that was built with an
+    // artifact that was built using the source locations.
+    MATCH (artifact)<-[:BUILT_WITH]-(:Artifact)<-[:EMBEDS]-(:Artifact {{type: 'container'}})
+        <-[:PRODUCED]-(with_built_with_artifact:Build)
+    RETURN with_built_with_artifact.id
+    """.format(', '.join(repr(artifact_id) for artifact_id in affected_artifact_ids))
+    results, _ = neomodel.db.cypher_query(query)
+    container_builds_embed_artifact_built_with_sl = set([r[0] for r in results])
+
+    return list(builds_built_with_affected_container.union(
+        container_builds_embed_artifact_built_with_sl))

--- a/assayist/common/models/content.py
+++ b/assayist/common/models/content.py
@@ -20,7 +20,7 @@ class Build(AssayistStructuredNode):
     # Call it "id_" to not overshadow the Neo4j internal ID used by neomodel, but call
     # it "id" in Neo4j
     id_ = StringProperty(db_property='id', required=True, unique_index=True)
-    type_ = StringProperty(db_property='type', required=True)
+    type_ = StringProperty(db_property='type', required=True, index=True)
 
     # The artifacts that were produced by this build
     artifacts = RelationshipTo('Artifact', 'PRODUCED')
@@ -51,7 +51,7 @@ class Artifact(AssayistStructuredNode):
     archive_id = StringProperty(required=True, index=True)
     filename = StringProperty()
     # A one-word description of the type of file this describes (to aid in filtering)
-    type_ = StringProperty(required=True, db_property='type', choices=TYPES)
+    type_ = StringProperty(required=True, db_property='type', choices=TYPES, index=True)
 
     # The artifacts this artifact is embedded in
     artifacts_embedded_in = RelationshipFrom('Artifact', 'EMBEDS')

--- a/assayist/common/models/content.py
+++ b/assayist/common/models/content.py
@@ -20,7 +20,7 @@ class Build(AssayistStructuredNode):
     # Call it "id_" to not overshadow the Neo4j internal ID used by neomodel, but call
     # it "id" in Neo4j
     id_ = StringProperty(db_property='id', required=True, unique_index=True)
-    type_ = StringProperty(db_property='type')
+    type_ = StringProperty(db_property='type', required=True)
 
     # The artifacts that were produced by this build
     artifacts = RelationshipTo('Artifact', 'PRODUCED')

--- a/tests/client/test_query.py
+++ b/tests/client/test_query.py
@@ -2,8 +2,7 @@
 
 from assayist.client import query
 from assayist.common.models.content import Artifact, Build
-from assayist.common.models.source import Component
-from assayist.common.models.source import SourceLocation
+from assayist.common.models.source import SourceLocation, Component
 
 
 def test_get_container_sources():
@@ -273,3 +272,148 @@ def test_get_source_components_for_build():
     }
 
     assert query.get_source_components_for_build('4000') == expected
+
+
+def test_get_current_and_previous_versions():
+    """Test the get_current_and_previous_versions function."""
+    go = Component(
+        canonical_name='golang', canonical_type='generic', canonical_namespace='redhat').save()
+    next_sl = None
+    url = 'git://pkgs.domain.local/rpms/golang?#fed96461b05c0078e537c93a3fe974e8b334{version}'
+    for version in ('1.9.7', '1.9.6', '1.9.5', '1.9.4', '1.9.3'):
+        sl = SourceLocation(
+            url=url.format(version=version.replace('.', '')), canonical_version=version).save()
+        sl.component.connect(go)
+        if next_sl:
+            next_sl.previous_version.connect(sl)
+        next_sl = sl
+
+    rv = query.get_current_and_previous_versions('golang', 'generic', '1.9.6')
+    versions = set([result['canonical_version'] for result in rv])
+    assert versions == set(['1.9.6', '1.9.5', '1.9.4', '1.9.3'])
+
+
+def test_get_container_built_with_artifact():
+    """
+    Test the test_get_container_built_with_artifact function.
+
+    This test data creates a scenario where there are container builds with vulnerable golang
+    RPMs embedded, that are used during multi-stage builds. There is also a container with the
+    prometheus RPM embedded, but the prometheus RPM was built with a vulnerable version of the
+    golang RPMs.
+    """
+    expected = set()
+    api_input = []
+    queried_sl_versions = {'1.9.6', '1.9.5', '1.9.3'}
+    go = Component(
+        canonical_name='golang', canonical_type='generic', canonical_namespace='redhat').save()
+
+    artifact_counter = 0
+    build_counter = 0
+    next_sl = None
+    url = 'git://pkgs.domain.local/rpms/golang?#fed96461b05c0078e537c93a3fe974e8b334{version}'
+
+    for version in ('1.9.7', '1.9.6', '1.9.5', '1.9.4', '1.9.3'):
+        sl = SourceLocation(
+            url=url.format(version=version.replace('.', '')), canonical_version=version).save()
+        sl.component.connect(go)
+        if next_sl:
+            next_sl.previous_version.connect(sl)
+        if version in queried_sl_versions:
+            api_input.append({'url': sl.url})
+        go_build = Build(id_=build_counter, type_='rpm').save()
+        go_build.source_location.connect(sl)
+        build_counter += 1
+
+        go_src_rpm_artifact = Artifact(archive_id=artifact_counter, type_='rpm', architecture='src',
+                                       filename=f'golang-{version}-1.el7.src.rpm').save()
+        go_src_rpm_artifact.build.connect(go_build)
+        artifact_counter += 1
+
+        # Don't create container builds for version 1.9.3 because it'll be used by prometheus below
+        # to test another part of the query
+        if version != '1.9.3':
+            go_container_build = Build(id_=build_counter, type_='container').save()
+            build_counter += 1
+
+            content_container_build = Build(id_=build_counter, type_='container').save()
+            if version in queried_sl_versions:
+                # All the content containers are built with a container with a vulnerable golang
+                # RPM, but since we only query for certain source location versions of golang, only
+                # add those we are searching for.
+                expected.add(str(content_container_build.id_))
+            build_counter += 1
+
+        for noarch_rpm in ('docs', 'misc', 'src', 'tests'):
+            go_noarch_artifact = Artifact(
+                archive_id=artifact_counter, type_='rpm', architecture='noarch',
+                filename=f'golang-{noarch_rpm}-{version}-1.el7.noarch.rpm').save()
+            go_noarch_artifact.build.connect(go_build)
+            artifact_counter += 1
+
+        for arch in ('aarch64', 'x86_64', 'ppc64le', 's390x'):
+            go_artifact = Artifact(archive_id=artifact_counter, type_='rpm', architecture=arch,
+                                   filename=f'golang-{version}-1.el7.{arch}.rpm').save()
+            go_artifact.build.connect(go_build)
+            artifact_counter += 1
+            gobin_artifact = Artifact(archive_id=artifact_counter, type_='rpm', architecture=arch,
+                                      filename=f'golang-bin-{version}-1.el7.{arch}.rpm').save()
+            gobin_artifact.build.connect(go_build)
+            artifact_counter += 1
+
+            if version != '1.9.3':
+                go_container_build_artifact = Artifact(
+                    archive_id=artifact_counter, type_='container', architecture=arch).save()
+                go_container_build_artifact.build.connect(go_container_build)
+                go_container_build_artifact.embedded_artifacts.connect(go_artifact)
+                go_container_build_artifact.embedded_artifacts.connect(gobin_artifact)
+                artifact_counter += 1
+
+                content_container_artifact = Artifact(
+                    archive_id=artifact_counter, type_='container', architecture=arch).save()
+                content_container_artifact.build.connect(content_container_build)
+                content_container_artifact.buildroot_artifacts.connect(go_container_build_artifact)
+                artifact_counter += 1
+
+        next_sl = sl
+
+    prometheus = Component(
+        canonical_name='prometheus', canonical_type='generic', canonical_namespace='redhat').save()
+    prometheus_url = ('git://pkgs.domain.local/rpms/golang-github-prometheus-prometheus?#41d8a98364'
+                      'a9c631c7f663bbda8942cb2741df49')
+    prometheus_sl = SourceLocation(url=prometheus_url, canonical_version='2.1.0').save()
+    prometheus_sl.component.connect(prometheus)
+    prometheus_build = Build(id_=build_counter, type_='rpm').save()
+    prometheus_build.source_location.connect(prometheus_sl)
+    build_counter += 1
+    prometheus_src_rpm_artifact = Artifact(
+        archive_id=artifact_counter, type_='rpm', architecture='src',
+        filename='golang-github-prometheus-prometheus-2.2.1-1.gitbc6058c.el7.src.rpm').save()
+    prometheus_src_rpm_artifact.build.connect(go_build)
+    artifact_counter += 1
+    prometheus_container_build = Build(id_=build_counter, type_='container').save()
+    # This prometheus container will embed a prometheus RPM that was built with a vulnerable golang
+    # RPM, and 1.9.3 is part of the query
+    expected.add(str(prometheus_container_build.id_))
+    build_counter += 1
+
+    for arch in ('x86_64', 's390x', 'ppc64le'):
+        prometheus_artifact = Artifact(
+            archive_id=artifact_counter, type_='rpm', architecture=arch,
+            filename=f'prometheus-2.2.1-1.gitbc6058c.el7.{arch}.rpm').save()
+        prometheus_artifact.build.connect(prometheus_build)
+        # Set the 1.9.3 go artifacts to be buildroot artifacts
+        go_artifact = Artifact.nodes.get(filename=f'golang-1.9.3-1.el7.{arch}.rpm')
+        prometheus_artifact.buildroot_artifacts.connect(go_artifact)
+        gobin_artifact = Artifact.nodes.get(filename=f'golang-bin-1.9.3-1.el7.{arch}.rpm')
+        prometheus_artifact.buildroot_artifacts.connect(gobin_artifact)
+        artifact_counter += 1
+        prometheus_container_artifact = Artifact(
+            archive_id=artifact_counter, type_='container', architecture=arch).save()
+        prometheus_container_artifact.build.connect(prometheus_container_build)
+        prometheus_container_artifact.embedded_artifacts.connect(prometheus_artifact)
+        artifact_counter += 1
+
+    rv = query.get_container_built_with_sources(api_input)
+
+    assert set(rv) == expected


### PR DESCRIPTION
This finds any container build that:
* embeds artifacts that were built with artifacts built from the input and related source locations
* was built with a container that embeds artifacts that were built with the input and related source locations