### PR TITLE
FACTORY-3327: Migrate the data fetcher script to python

### DIFF
--- a/assayist/processor/base.py
+++ b/assayist/processor/base.py
@@ -14,14 +14,14 @@ from assayist.processor.logging import log
 class Analyzer(ABC):
     """Base Abstract class that analyzers will inherit from."""
 
-    METADATA_DIR = '/metadata/'
-    MESSAGE_FILE = METADATA_DIR + 'message.json'
-    BUILD_FILE = METADATA_DIR + 'buildinfo.json'
-    TASK_FILE = METADATA_DIR + 'taskinfo.json'
-    RPM_FILE = METADATA_DIR + 'rpms.json'
-    ARCHIVE_FILE = METADATA_DIR + 'archives.json'
-    IMAGE_RPM_FILE = METADATA_DIR + 'image-rpms.json'
-    BUILDROOT_FILE = METADATA_DIR + 'buildroot-components.json'
+    METADATA_DIR = '/metadata'
+    BUILD_FILE = 'buildinfo.json'
+    TASK_FILE = 'taskinfo.json'
+    MAVEN_FILE = 'maveninfo.json'
+    RPM_FILE = 'rpms.json'
+    ARCHIVE_FILE = 'archives.json'
+    IMAGE_RPM_FILE = 'image-rpms.json'
+    BUILDROOT_FILE = 'buildroot-components.json'
 
     def main(self):
         """Call this to run the analyzer."""
@@ -41,20 +41,22 @@ class Analyzer(ABC):
     def run(self):
         """Implement analyzer code here in your subclass."""
 
-    def read_metadata_file(self, in_file):
+    def read_metadata_file(self, in_file, in_dir=METADATA_DIR):
         """
         Read and return the specified json metadata file or an empty dict.
 
-        :param str in_file: The path to the input file to read. Probably one of the class constants.
+        :param str in_file: The name of the input file to read. Probably one of the class constants.
+        :param str in_dir: The directory the file is in. Defaults to METADATA_DIR.
         :return: a dict or list read from the file, or an empty dict
         :rtype: {}
         :raises ValueError: if the file was not valid json content
         """
-        if os.path.isfile(in_file):
-            with open(in_file, 'r') as f:
+        filename = os.path.join(in_dir, in_file)
+        if os.path.isfile(filename):
+            with open(filename, 'r') as f:
                 return json.load(f)
         else:
-            log.debug('File not found: %s, returning empty dict', in_file)
+            log.debug('File not found: %s, returning empty dict', filename)
             return {}
 
     def __create_or_update_artifact(self, archive_id, archive_type, arch, filename, checksum):

--- a/assayist/processor/main_analyzer.py
+++ b/assayist/processor/main_analyzer.py
@@ -57,11 +57,11 @@ class MainAnalyzer(Analyzer):
             ctype = 'rpm'
             cversion = '%s-%s' % (build_info['version'], build_info['release'])
         elif build_type == 'maven':
-            # What we really want is the contents of the "Maven groupId" etc fields.
-            # However they don't seem to be included in the brew response?!
-            # Instead let's parse it out with what is (as best as I can tell) the algorithm.
-            cnamespace, cname = build_info['name'].split('-', 1)
-            cversion = build_info['version'].replace('_', '-')
+            # If it's a maven build then the maven info file should exist with the info we need.
+            maven_info = self.read_metadata_file(self.MAVEN_FILE)
+            cnamespace = maven_info['group_id']
+            cname = maven_info['artifact_id']
+            cversion = maven_info['version']
             ctype = 'java'
         elif build_type == 'buildContainer':
             # Theoretically this should exist for buildContainer builds.

--- a/scripts/download-unpack-build.py
+++ b/scripts/download-unpack-build.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import os
 
-from assayist.processor.utils import download_build, unpack_artifacts, download_source
+from assayist.processor import utils
 
 
 # Always set the logging to INFO
@@ -28,18 +28,21 @@ except ValueError:
 
 output_dir = args.output_dir or '.'
 
+output_metadata_dir = os.path.join(output_dir, 'metadata')
 output_files_dir = os.path.join(output_dir, 'output_files')
 output_source_dir = os.path.join(output_dir, 'source')
 unpacked_archives_dir = os.path.join(output_dir, 'unpacked_archives')
 
-for directory in (output_files_dir, unpacked_archives_dir, output_source_dir):
+for directory in (output_metadata_dir, output_files_dir, unpacked_archives_dir, output_source_dir):
     if not os.path.isdir(directory):
         os.mkdir(directory)
 
-artifacts, build_info = download_build(build_identifier, output_files_dir)
-download_source(build_info, output_source_dir)
-unpack_artifacts(artifacts, unpacked_archives_dir)
+utils.download_build_data(build_identifier, output_metadata_dir)
+artifacts, build_info = utils.download_build(build_identifier, output_files_dir)
+utils.download_source(build_info, output_source_dir)
+utils.unpack_artifacts(artifacts, unpacked_archives_dir)
 
+log.info(f'See the downloaded brew metadata at {output_metadata_dir}')
 log.info(f'See the downloaded archives at {output_files_dir}')
 log.info(f'See the downloaded source at {output_source_dir}')
 log.info(f'See the unpacked archives at {unpacked_archives_dir}')

--- a/tests/processor/test_main.py
+++ b/tests/processor/test_main.py
@@ -291,12 +291,14 @@ def test__construct_and_save_component():
     component.id  # exists, hence is saved
 
     btype = 'maven'
-    binfo = {
-        'name': 'com.redhat.fuse.eap-fuse-eap',
-        'version': '6.3.0.redhat_356',
-        'release': '1'}
-    component, version = analyzer._construct_and_save_component(btype, binfo)
-    assert version == '6.3.0.redhat-356'
+    maven_info = {
+        'group_id': 'com.redhat.fuse.eap',
+        'artifact_id': 'fuse-eap',
+        'version': '6.3.0.redhat_356'}
+    with mock.patch.object(analyzer, 'read_metadata_file') as mocked_f:
+        mocked_f.return_value = maven_info
+        component, version = analyzer._construct_and_save_component(btype, binfo)
+    assert version == '6.3.0.redhat_356'
     assert component.canonical_namespace == 'com.redhat.fuse.eap'
     assert component.canonical_name == 'fuse-eap'
     assert component.canonical_type == 'java'
@@ -313,8 +315,6 @@ def test__construct_and_save_component():
 
 def read_metadata_test_data(self, FILE):
     """Mock out this function so we can use test data."""
-    if FILE == base.Analyzer.MESSAGE_FILE:
-        return {'info': {'build_id': 759153}}
     if FILE == base.Analyzer.BUILD_FILE:
         return {'id': 759153,
                 'source': SOURCE_URL,
@@ -323,6 +323,8 @@ def read_metadata_test_data(self, FILE):
                 'release': '4'}
     if FILE == base.Analyzer.TASK_FILE:
         return {'method': 'buildContainer'}
+    if FILE == base.Analyzer.MAVEN_FILE:
+        return {'group_id': 'com.example', 'artifact_id': 'maven', 'version': '1'}
     if FILE == base.Analyzer.RPM_FILE:
         return [VIM_1_2_3, SSH_9_8_7]
     if FILE == base.Analyzer.ARCHIVE_FILE:


### PR DESCRIPTION
This update migrates the data fetcher script to python. It also:
* Adds tests for it.
* Removes the assumption of a message.json file (as discussed in call)
* Adds the logic for the getMavenBuild command and uses those versions for maven Components.