### PR TITLE
Add script to run main analyzer and parameterize metadata directory location

### DIFF
--- a/assayist/processor/base.py
+++ b/assayist/processor/base.py
@@ -14,7 +14,6 @@ from assayist.processor.logging import log
 class Analyzer(ABC):
     """Base Abstract class that analyzers will inherit from."""
 
-    METADATA_DIR = '/metadata'
     BUILD_FILE = 'buildinfo.json'
     TASK_FILE = 'taskinfo.json'
     MAVEN_FILE = 'maveninfo.json'
@@ -23,8 +22,13 @@ class Analyzer(ABC):
     IMAGE_RPM_FILE = 'image-rpms.json'
     BUILDROOT_FILE = 'buildroot-components.json'
 
-    def main(self):
-        """Call this to run the analyzer."""
+    def main(self, input_dir='/metadata'):
+        """
+        Call this to run the analyzer.
+
+        :param str input_dir: The directory in which to find the files.
+        """
+        self.input_dir = input_dir
         neomodel.db.set_connection(config.DATABASE_URL)
         # run the analyzer in a transaction
         neomodel.db.begin()
@@ -41,17 +45,16 @@ class Analyzer(ABC):
     def run(self):
         """Implement analyzer code here in your subclass."""
 
-    def read_metadata_file(self, in_file, in_dir=METADATA_DIR):
+    def read_metadata_file(self, in_file):
         """
         Read and return the specified json metadata file or an empty dict.
 
         :param str in_file: The name of the input file to read. Probably one of the class constants.
-        :param str in_dir: The directory the file is in. Defaults to METADATA_DIR.
         :return: a dict or list read from the file, or an empty dict
         :rtype: {}
         :raises ValueError: if the file was not valid json content
         """
-        filename = os.path.join(in_dir, in_file)
+        filename = os.path.join(self.input_dir, in_file)
         if os.path.isfile(filename):
             with open(filename, 'r') as f:
                 return json.load(f)

--- a/assayist/processor/main_analyzer.py
+++ b/assayist/processor/main_analyzer.py
@@ -151,7 +151,3 @@ class MainAnalyzer(Analyzer):
                     archive.embedded_artifacts.connect(rpm)
 
         self._read_and_save_buildroots()
-
-
-if __name__ == '__main__':
-    MainAnalyzer.main()

--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -41,13 +41,13 @@ def write_file(data, in_dir, in_file):
 
     :param dict/list data: the data to write out to JSON. Must be serializable.
     :param str in_file: The name of the input file to read. Probably one of the class constants.
-    :param str in_dir: The directory the file is in. Defaults to METADATA_DIR.
+    :param str in_dir: The directory the file is in.
     """
     with open(os.path.join(in_dir, in_file), 'w') as f:
         json.dump(data, f)
 
 
-def download_build_data(build_identifier, output_dir=Analyzer.METADATA_DIR):
+def download_build_data(build_identifier, output_dir='/metadata'):
     """
     Download the JSON data associated with a build.
 

--- a/scripts/run-main-analyzer.py
+++ b/scripts/run-main-analyzer.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+import argparse
+import os
+
+from assayist.processor.main_analyzer import MainAnalyzer
+
+parser = argparse.ArgumentParser(
+    description='Download the artifacts associated with a build and unpack them')
+parser.add_argument('--input-dir', type=str,
+                    help='The diretory containing the "metadata" directory')
+args = parser.parse_args()
+
+input_dir = args.input_dir or '.'
+
+input_dir = os.path.join(input_dir, 'metadata')
+
+MainAnalyzer().main(input_dir)


### PR DESCRIPTION
We needed a script for jenkins to call to run the main analyzer. This also makes the location of the metadata parameterized so that it can be easily controlled by jenkins.