### PR TITLE
The git utility is required by processoer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y install \
   --setopt=tsflags=nodocs \
   # Install brewkoji for the koji.conf.d config file
   brewkoji \
+  git-core \
   python3-koji \
   python3-neomodel \
   && dnf clean all


### PR DESCRIPTION
  Traceback (most recent call last):
    File "/src/scripts/download-unpack-build.py", line 42, in <module>
      utils.download_source(build_info, output_source_dir)
    File "/src/assayist/processor/utils.py", line 169, in download_source
      _assert_command('git')
    File "/src/assayist/processor/utils.py", line 35, in _assert_command
      raise RuntimeError(f'The command "{cmd_name}" is not installed and is required')
  RuntimeError: The command "git" is not installed and is required