### PR TITLE
Fix usage old Popen object

### DIFF
--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -187,8 +187,8 @@ def download_source(build_info, output_dir):
         raise RuntimeError(f'The command "{" ".join(cmd)}" failed with: {error_output}')
 
     cmd = ['git', 'reset', '--hard', commit_id]
-    subprocess.Popen(cmd, cwd=os.path.join(output_dir, component),
-                     stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,)
+    process = subprocess.Popen(cmd, cwd=os.path.join(output_dir, component),
+                               stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
     _, error_output = process.communicate()
     error_output = error_output.decode('utf-8')


### PR DESCRIPTION
We did not adding newly created object from subprocess.Popen for
the command "git reset --hard". Therefore we got and error
while trying to read already closed file (for stderr)

Traceback (most recent call last):
  File "/src/scripts/download-unpack-build.py", line 42, in <module>
    utils.download_source(build_info, output_source_dir)
  File "/src/assayist/processor/utils.py", line 193, in download_source
    _, error_output = process.communicate()
  File "/usr/lib64/python3.6/subprocess.py", line 833, in communicate
    stderr = self.stderr.read()
ValueError: read of closed file