### PR TITLE
WIP: Remove required constraint on canonical_namespace

### DIFF
--- a/assayist/common/models/source.py
+++ b/assayist/common/models/source.py
@@ -15,7 +15,7 @@ class Component(AssayistStructuredNode):
     See https://github.com/package-url/purl-spec for information on what makes something canonical.
     """
 
-    canonical_namespace = StringProperty(required=True)
+    canonical_namespace = StringProperty()
     canonical_name = StringProperty(required=True, index=True)
     canonical_type = StringProperty(required=True, index=True)
     alternative_names = ArrayProperty(index=True)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -257,31 +257,30 @@ class SourceLocationFactory(ModelFactory):
 class ComponentFactory(ModelFactory):
     """Factory class for Component model instances."""
 
-    # TODO: why is canonical-namespace required?
     COMPONENTS = {
-        'requests': ('', 'requests', 'pypi', ['python3-requests', 'python-requests']),
+        'requests': (None, 'requests', 'pypi', ['python3-requests', 'python-requests']),
         'configmap-reload': ('github.com/jimmidyson', 'configmap-reload', 'golang', []),
         'fsnotify.v1': ('gopkg.in', 'fsnotify.v1', 'golang', []),
         'sys': ('golang.org/x', 'sys', 'golang', []),
-        'commonjava': ('', 'org.commonjava:commonjava-parent', 'maven', []),
+        'commonjava': (None, 'org.commonjava:commonjava-parent', 'maven', []),
         'etcd': ('github.com/coreos', 'etcd', 'golang', []),
-        'bash': ('', 'bash', 'generic', []),
-        'yum-utils': ('', 'yum-utils', 'generic', []),
-        'rsyslog': ('', 'rsyslog', 'generic', []),
+        'bash': (None, 'bash', 'generic', []),
+        'yum-utils': (None, 'yum-utils', 'generic', []),
+        'rsyslog': (None, 'rsyslog', 'generic', []),
         'com.redhat.lightblue.client-lightblue-client-core': (
-            '', 'com.redhat.lightblue.client:lightblue-client-core', 'maven', []
+            None, 'com.redhat.lightblue.client:lightblue-client-core', 'maven', []
         ),
         'com.redhat.fuse.eap-fuse-eap': (
-            '', 'com.redhat.fuse.eap:fuse-eap', 'maven', []
+            None, 'com.redhat.fuse.eap:fuse-eap', 'maven', []
         ),
-        'rsyslog-container': ('', 'rsyslog-container', 'docker', []),
+        'rsyslog-container': (None, 'rsyslog-container', 'docker', []),
         'openshift-enterprise-base-container': (
-            '', 'openshift-enterprise-base-container', 'docker', []
+            None, 'openshift-enterprise-base-container', 'docker', []
         ),
         'atomic-openshift-metrics-server-container': (
-            '', 'atomic-openshift-metrics-server-container', 'docker', []
+            None, 'atomic-openshift-metrics-server-container', 'docker', []
         ),
-        'jboss-eap-7-eap71': ('', 'jboss-eap-7-eap71', 'docker', []),
+        'jboss-eap-7-eap71': (None, 'jboss-eap-7-eap71', 'docker', []),
     }
 
     @classmethod


### PR DESCRIPTION
FACTORY-3422

The namespace part of the purl spec is marked as optional. Also, I couldn't reproduce issues with `get_or_create()` when not providing an attribute that is not required so not sure why it was required in the first place:

```python
In [1]: from assayist.common.models.source import Component

In [2]: Component.get_or_create({'canonical_name': 'hello', 'canonical_type': 'docker'})
Out[2]: [<Component: {'canonical_namespace': None, 'canonical_name': 'hello', 'canonical_type': 'docker', 'alternative_names': None, 'id': 77}>]

In [3]: Component.get_or_create({'canonical_name': 'hello', 'canonical_type': 'docker'})
Out[3]: [<Component: {'canonical_namespace': None, 'canonical_name': 'hello', 'canonical_type': 'docker', 'alternative_names': None, 'id': 77}>]

In [4]: Component.get_or_create({'canonical_name': 'hello', 'canonical_type': 'docker', 'canonical_namespace': None})
Out[4]: [<Component: {'canonical_namespace': None, 'canonical_name': 'hello', 'canonical_type': 'docker', 'alternative_names': None, 'id': 77}>]
```



