### PR TITLE
Analyzer: define directory names and take top-level input dir in initializer

### DIFF
--- a/assayist/processor/base.py
+++ b/assayist/processor/base.py
@@ -50,6 +50,15 @@ def generic_key(x):
 class Analyzer(ABC):
     """Base Abstract class that analyzers will inherit from."""
 
+    # Directory paths, relative to input_dir
+    METADATA_DIR = 'metadata'
+    FILES_DIR = 'output_files'
+    SOURCE_DIR = 'source'
+    UNPACKED_ARCHIVES_DIR = 'unpacked_archives'
+    UNPACKED_CONTAINER_LAYER_DIR = os.path.join(UNPACKED_ARCHIVES_DIR,
+                                                'container_layer')
+
+    # Metadata files (use with read_metadata_file)
     BUILD_FILE = 'buildinfo.json'
     TASK_FILE = 'taskinfo.json'
     MAVEN_FILE = 'maveninfo.json'
@@ -58,7 +67,7 @@ class Analyzer(ABC):
     IMAGE_RPM_FILE = 'image-rpms.json'
     BUILDROOT_FILE = 'buildroot-components.json'
 
-    def __init__(self, input_dir='/metadata'):
+    def __init__(self, input_dir='/'):
         """
         Initialize the Analyzer class.
 
@@ -93,7 +102,7 @@ class Analyzer(ABC):
         :rtype: {}
         :raises ValueError: if the file was not valid json content
         """
-        filename = os.path.join(self.input_dir, in_file)
+        filename = os.path.join(self.input_dir, self.METADATA_DIR, in_file)
         if os.path.isfile(filename):
             with open(filename, 'r') as f:
                 return json.load(f)
@@ -275,7 +284,8 @@ class Analyzer(ABC):
         file_path = path_in_container.lstrip('/')
 
         container_layer_dir = os.path.join(
-            self.input_dir, 'unpacked_archives', 'container_layer', container_archive['filename'])
+            self.input_dir, self.UNPACKED_CONTAINER_LAYER_DIR,
+            container_archive['filename'])
         if not os.path.isdir(container_layer_dir):
             raise RuntimeError(f'The path "{container_layer_dir}" is not a directory')
 

--- a/scripts/run-main-analyzer.py
+++ b/scripts/run-main-analyzer.py
@@ -2,18 +2,15 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 import argparse
-import os
 
 from assayist.processor.main_analyzer import MainAnalyzer
 
 parser = argparse.ArgumentParser(
     description='Download the artifacts associated with a build and unpack them')
 parser.add_argument('--input-dir', type=str,
-                    help='The diretory containing the "metadata" directory')
+                    help='The directory containing the "metadata" directory')
 args = parser.parse_args()
 
 input_dir = args.input_dir or '.'
-
-input_dir = os.path.join(input_dir, 'metadata')
 
 MainAnalyzer(input_dir).main()


### PR DESCRIPTION
Previously input_dir was set to the location of the 'metadata' directory. Instead, it is now the location which has subdirectories 'metadata', 'source' etc and those subdirectory names are stored in class attributes.

Signed-off-by: Tim Waugh <twaugh@redhat.com>