### PR TITLE
Resolve any symlinks in the paths to the files to claim

### DIFF
--- a/tests/processor/test_base.py
+++ b/tests/processor/test_base.py
@@ -45,3 +45,48 @@ def test_claim_container_file():
         analyzer.claim_container_file(archive, '/test_dir/test_file.txt')
         assert os.path.exists(test_dir) is True
         assert os.path.exists(test_file) is False
+
+
+def test_claim_container_file_through_symlink():
+    """Test that the claim_container_file method follows a symlink properly."""
+    container_file_name = 'docker-image-123456'
+    with tempfile.TemporaryDirectory() as temp_dir:
+        layer_dir = os.path.join(
+            temp_dir, 'unpacked_archives', 'container_layer', container_file_name)
+        test_dir = os.path.join(layer_dir, 'test_dir')
+        os.makedirs(test_dir)
+        test_file = os.path.join(test_dir, 'test_file.txt')
+        with open(test_file, 'w+') as f:
+            f.write('something')
+        test_symlink = os.path.join(layer_dir, 'test_symlink')
+        os.symlink('/test_dir', test_symlink)
+
+        analyzer = DummyAnalyzer(temp_dir)
+        archive = {'filename': container_file_name}
+        analyzer.claim_container_file(archive, '/test_symlink/test_file.txt')
+        assert os.path.exists(test_dir) is True
+        assert os.path.exists(test_file) is False
+
+
+def test_claim_container_file_through_multiple_symlink():
+    """Test that the claim_container_file method follows multiple symlinks properly."""
+    container_file_name = 'docker-image-123456'
+    with tempfile.TemporaryDirectory() as temp_dir:
+        layer_dir = os.path.join(
+            temp_dir, 'unpacked_archives', 'container_layer', container_file_name)
+        test_dir = os.path.join(layer_dir, 'test_dir')
+        test_subdir = os.path.join(test_dir, 'test_subdir')
+        os.makedirs(test_subdir)
+        test_file = os.path.join(test_subdir, 'test_file.txt')
+        with open(test_file, 'w+') as f:
+            f.write('something')
+        test_symlink = os.path.join(layer_dir, 'test_symlink')
+        os.symlink('/test_dir', test_symlink)
+        test_symlink2 = os.path.join(test_dir, 'test_symlink2')
+        os.symlink('/test_dir/test_subdir', test_symlink2)
+
+        analyzer = DummyAnalyzer(temp_dir)
+        archive = {'filename': container_file_name}
+        analyzer.claim_container_file(archive, '/test_symlink/test_symlink2/test_file.txt')
+        assert os.path.exists(test_subdir) is True
+        assert os.path.exists(test_file) is False


### PR DESCRIPTION
This resolves an issue where if you were trying to claim `/opt/rh/httpd24/root/etc/httpd/httpd.conf` in the container but `/opt/rh/httpd24/root/etc/httpd` is a symlink to `/etc/httpd`.

This also contains a separate commit to make the logic used in `claim_container_file` reusable as requested by @mprpic.