### PR TITLE
Add missing dependency into container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf -y install \
   # Install brewkoji for the koji.conf.d config file
   brewkoji \
   git-core \
+  cpio \
   python3-koji \
   python3-neomodel \
   && dnf clean all


### PR DESCRIPTION
We need the cpio binary in image for the script download-unpack-build.py.

Unpacking dnf-4.0.4-1.fc30.noarch
Traceback (most recent call last):
  File "/src/scripts/download-unpack-build.py", line 45, in <module>
    utils.unpack_artifacts(artifacts, unpacked_archives_dir)
  File "/src/assayist/processor/utils.py", line 337, in unpack_artifacts
    unpack_rpm(artifact, output_subdir)
  File "/src/assayist/processor/utils.py", line 251, in unpack_rpm
    _assert_command('cpio')
  File "/src/assayist/processor/utils.py", line 34, in _assert_command
    raise RuntimeError(f'The command "{cmd_name}" is not installed and is required')
RuntimeError: The command "cpio" is not installed and is required