### PR TITLE
Find stubbed builds

### DIFF
--- a/scripts/find-stubbed-builds.py
+++ b/scripts/find-stubbed-builds.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0+
+
+import argparse
+
+from assayist.common.models.content import Build
+
+parser = argparse.ArgumentParser(description='Return a list of stubbed builds')
+args = parser.parse_args()
+
+stubbed_builds = Build.nodes.has(source_location=False).all()
+
+for build in stubbed_builds:
+    print(build.id_)


### PR DESCRIPTION
FACTORY-3509

This script can be used to run from a periodic Jenkins job and trigger the
analyzer pipeline for each found build.