### PR TITLE
Add missing dependency for go analyzer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN dnf -y install \
   --setopt=tsflags=nodocs \
   # Install brewkoji for the koji.conf.d config file
   brewkoji \
+  # Install rhpkg for go analyzer
+  rhpkg \
   git-core \
   cpio \
   python3-koji \


### PR DESCRIPTION
 Traceback (most recent call last):
   File "/src/scripts/download-unpack-build.py", line 44, in <module>
     utils.download_source(build_info, output_source_dir)
   File "/src/assayist/processor/utils.py", line 186, in download_source
     assert_command(sources_cmd[0])
   File "/src/assayist/processor/utils.py", line 34, in assert_command
     raise RuntimeError(f'The command "{cmd_name}" is not installed and is required')
 RuntimeError: The command "rhpkg" is not installed and is required