### PR TITLE
Use multicall to get RPM files

### DIFF
--- a/tests/processor/test_container_rpm_analyzer.py
+++ b/tests/processor/test_container_rpm_analyzer.py
@@ -23,9 +23,9 @@ def test_get_rpms_diff():
 def test_process_embedded_rpms(mock_claim_cf):
     """Test that the _process_embedded_rpms method creates the correct entries in Neo4j."""
     mock_session = mock.Mock()
-    mock_session.listRPMFiles.side_effect = [
-        [{'name': '/etc/app/app.conf'}, {'name': '/usr/bin/app'}],
-        [{'name': '/etc/app2/app.conf'}, {'name': '/usr/bin/app2'}]
+    mock_session.multiCall.return_value = [
+        [[{'name': '/etc/app/app.conf'}, {'name': '/usr/bin/app'}]],
+        [[{'name': '/etc/app2/app.conf'}, {'name': '/usr/bin/app2'}]],
     ]
     archive = {'id': 1234, 'btype': 'container', 'extra': {'image': {'arch': 'x86_64'}}}
     rpms = [


### PR DESCRIPTION
This reduces the run time of the container RPM analyzer from ~15min to ~1min.