### PR TITLE
Fix fetching sources from dist-git

### DIFF
--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -179,7 +179,7 @@ def download_source(build_info, output_dir, sources_cmd=None):
         or None for the default (['rhpkg', 'sources'])
     """
     if sources_cmd is None:
-        sources_cmd = ['rhpkg', 'sources']
+        sources_cmd = ['rhpkg', '--user=1001', 'sources']
 
     # Make sure the commands we'll run are installed
     assert_command('git')

--- a/tests/processor/test_utils.py
+++ b/tests/processor/test_utils.py
@@ -211,7 +211,7 @@ def test_download_source(m_popen, m_assert_command):
         mock.call(['git', 'reset', '--hard', '4a4109c3e85908b6899b1aa291570f7c7b5a0cb5'],
                   cwd='/some/path', stdout=subprocess.DEVNULL, stderr=subprocess.PIPE),
         mock.call().communicate(),
-        mock.call(['rhpkg', 'sources'],
+        mock.call(['rhpkg', '--user=1001', 'sources'],
                   cwd='/some/path', stdout=subprocess.DEVNULL, stderr=subprocess.PIPE),
         mock.call().communicate(),
     ])


### PR DESCRIPTION
rhpkg fails if user is not in /etc/passwd.

  sh# docker run -ti --rm localhost/assayist-container bash
  bash-4.4$ cd /var/tmp/
  bash-4.4$ download-unpack-build.py --output-dir /var/tmp 797777
  Downloading build 797777 from Koji
  //snip
  Cloning source for 797777
  Downloading sources for 797777
  Traceback (most recent call last):
    File "/src/scripts/download-unpack-build.py", line 44, in <module>
      utils.download_source(build_info, output_source_dir)
    File "/src/assayist/processor/utils.py", line 223, in download_source
      raise RuntimeError(f'The command "{" ".join(cmd)}" failed with: {error_output}')
  RuntimeError: The command "git reset --hard 0f38a43f8d7098fa228fd8a9893015b883201ce5" failed with: Traceback (most recent call last):
    File "/usr/bin/rhpkg", line 16, in <module>
      main()
    File "/usr/lib/python2.7/site-packages/rhpkg/__main__.py", line 62, in main
      client.parse_cmdline()
    File "/usr/lib/python2.7/site-packages/pyrpkg/cli.py", line 2363, in parse_cmdline
      self.user = getpass.getuser()
    File "/usr/lib64/python2.7/getpass.py", line 158, in getuser
      return pwd.getpwuid(os.getuid())[0]
  KeyError: 'getpwuid(): uid not found: 1001'

And we do not have any username in container and moreover
uid in openshift is random and cannot be easily added to /etc/passwd

But this check is not important for fetching sources and we can override
it with any UID.

  bash-4.4$ getent passwd 1002 || echo fail
  fail
  bash-4.4$ rhpkg --user=1002 sources
  Downloading ldb-1.4.3.tar.gz
  ######################################################################## 100.0%