### PR TITLE
Fix incompatibility with python 3.6

### DIFF
--- a/assayist/processor/container_go_analyzer.py
+++ b/assayist/processor/container_go_analyzer.py
@@ -100,7 +100,7 @@ class ContainerGoAnalyzer(Analyzer):
 
             cmd = [self.BACKVENDOR] + options + [srcdir]
             log.info(f'Running {cmd}')
-            bv = subprocess.Popen(cmd, cwd=srcdir, text=True,
+            bv = subprocess.Popen(cmd, cwd=srcdir, universal_newlines=True,
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
 
@@ -171,7 +171,7 @@ class ContainerGoAnalyzer(Analyzer):
 
             cmd = [self.GOVERSION, '.']
             log.info(f'Running {cmd}')
-            gv = subprocess.Popen(cmd, cwd=layer_dir, text=True,
+            gv = subprocess.Popen(cmd, cwd=layer_dir, universal_newlines=True,
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
             (stdout, stderr) = gv.communicate()


### PR DESCRIPTION
Our container is based on fedora:28 which has only python 3.6
And the text argument to constructor of subprocess.Popen
was added in python 3.7

https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen

  New in version 3.7: text was added as a more readable alias for universal_newlines.

  sh$ run-analyzers.py --input-dir /home/jenkins/workspace
  EXITCODE   0INFO:assayist_processor:Running ['backvendor', '-debug', '-template', '\t{{.Ver}}\t{{.Repo}}\t{{.Rev}}', '-exclude-from', '/tmp/tmppee54xkg', '/home/jenkins/workspace/source']
  ERROR:assayist_processor:Error encountered executing Analyzer, rolling back transaction.
  Traceback (most recent call last):
    File "/src/assayist/processor/base.py", line 86, in main
      self.run()
    File "/src/assayist/processor/container_go_analyzer.py", line 70, in run
      excludes=dist_git_excludes)
    File "/src/assayist/processor/container_go_analyzer.py", line 105, in _process_source_code
      stderr=subprocess.PIPE)
  TypeError: __init__() got an unexpected keyword argument 'text'