### PR TITLE
Use type "build" for RPM builds

### DIFF
--- a/assayist/processor/container_rpm_analyzer.py
+++ b/assayist/processor/container_rpm_analyzer.py
@@ -80,7 +80,7 @@ class ContainerRPMAnalyzer(Analyzer):
 
             if rpm['build_id'] not in build_id_to_obj:
                 build_id_to_obj[rpm['build_id']] = content.Build.get_or_create({
-                    'id_': rpm['build_id'], 'type_': 'rpm'})[0]
+                    'id_': rpm['build_id'], 'type_': 'build'})[0]
             build_id_to_obj[rpm['build_id']].artifacts.connect(rpm_artifact_obj)
 
             self.koji_session.listRPMFiles(rpm['id'])

--- a/assayist/processor/loose_rpm_analyzer.py
+++ b/assayist/processor/loose_rpm_analyzer.py
@@ -62,7 +62,7 @@ class LooseRpmAnalyzer(Analyzer):
 
         build = content.Build.get_or_create({
             'id_': build_id,
-            'type_': 'rpm',
+            'type_': 'build',
         })[0]
 
         return build, rpm_info

--- a/tests/processor/test_loose_rpm_analyzer.py
+++ b/tests/processor/test_loose_rpm_analyzer.py
@@ -72,7 +72,7 @@ def test_get_related_build():
     # Create new build
     build, _ = analyzer._get_related_build('python-django-1.8.11-1.el7ost.noarch.rpm')
     assert build.id_ == str(RPM_INFO['build_id'])
-    assert build.type_ == 'rpm'
+    assert build.type_ == 'build'
     assert content.Build.nodes.get(id_=str(RPM_INFO['build_id']))
 
     # Check that no new build is created


### PR DESCRIPTION
Main analyzer sets the build type to `task['method']` and for RPM builds this
is "build".

FACTORY-3523