### PR TITLE
FACTORY-3553: Don't Traceback on module builds

### DIFF
--- a/assayist/processor/base.py
+++ b/assayist/processor/base.py
@@ -362,6 +362,25 @@ class Analyzer(ABC):
             return True
 
     @staticmethod
+    def is_module_build(build_info):
+        """
+        Perform a heuristic evaluation to determine if this is a module build.
+
+        :param dict build_info: the Koji build info to examine
+        :returns: a boolean determining if the build is a module
+        :rtype: bool
+        """
+        # Protect against the value being `None` or something else unexpected
+        extra = build_info.get('extra')
+        if not extra or not isinstance(extra, dict):
+            return False
+        typeinfo = extra.get('typeinfo')
+        if not typeinfo or not typeinfo.get('module'):
+            return False
+        else:
+            return True
+
+    @staticmethod
     def is_container_archive(archive):
         """
         Inspect the archive to see if its a container archive.

--- a/assayist/processor/loose_artifact_analyzer.py
+++ b/assayist/processor/loose_artifact_analyzer.py
@@ -36,6 +36,11 @@ class LooseArtifactAnalyzer(Analyzer):
         build_info = self.read_metadata_file(self.BUILD_FILE)
         build_id = build_info['id']
 
+        # There's nothing we care about in module builds, exit early.
+        if self.is_module_build(build_info):
+            log.info(f"Skipping build {build_id} because it's a module build")
+            return
+
         # Dir of all unpacked content to search for RPM files
         unpacked_content_path = os.path.join(self.input_dir, self.UNPACKED_ARCHIVES_DIR)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,9 +19,12 @@ RUN dnf -y install \
   git-core \
   cpio \
   python3-koji \
-  python3-neomodel \
   golang \
   && dnf clean all
+
+# We require at least neomodel 3.2.9 to get the bugfix in dd42548e4a3d484fd1265be834893f1212be680d.
+# Fedora currently only has rpms for 3.2.8. Let's install 3.3.0 from koji directly.
+RUN dnf -y install https://kojipkgs.fedoraproject.org//packages/python-neomodel/3.3.0/1.fc28/noarch/python3-neomodel-3.3.0-1.fc28.noarch.rpm
 
 # Tools needed for Go analysis
 RUN go get rsc.io/goversion

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -9,12 +9,15 @@ RUN dnf -y install \
   python3-flake8 \
   python3-koji \
   python3-mock \
-  python3-neomodel \
   python3-pytest \
   python3-pytest-cov \
   && dnf clean all
-RUN pip3 install flake8-docstrings
 
+# We require at least neomodel 3.2.9 to get the bugfix in dd42548e4a3d484fd1265be834893f1212be680d.
+# Fedora currently only has rpms for 3.2.8. Let's install 3.3.0 from koji directly.
+RUN dnf -y install https://kojipkgs.fedoraproject.org//packages/python-neomodel/3.3.0/1.fc28/noarch/python3-neomodel-3.3.0-1.fc28.noarch.rpm
+
+RUN pip3 install flake8-docstrings
 VOLUME /src
 WORKDIR /src
 # Inspired from https://github.com/neo4j-contrib/neomodel/blob/master/tests-with-docker-compose.sh

--- a/scripts/find-stubbed-builds.py
+++ b/scripts/find-stubbed-builds.py
@@ -11,7 +11,7 @@ parser = argparse.ArgumentParser(description='Return a list of stubbed builds')
 args = parser.parse_args()
 
 db.set_connection(config.DATABASE_URL)
-stubbed_builds = Build.nodes.has(source_location=False).all()
+stubbed_builds = Build.nodes.has(source_location=False).filter(type___ne='module')
 
 for build in stubbed_builds:
     print(build.id_)

--- a/tests/processor/test_base.py
+++ b/tests/processor/test_base.py
@@ -18,6 +18,17 @@ class DummyAnalyzer(BaseAnalyzer):
 
 @pytest.mark.parametrize('build_info,expected', [
     ({'extra': None}, False),
+    ({'extra': {}}, False),
+    ({'extra': {'typeinfo': {}}}, False),
+    ({'extra': {'typeinfo': {'module': {'x': 1}}}}, True),
+])
+def test_is_module_build(build_info, expected):
+    """Test that the is_module_build method properly parses the passed-in build info."""
+    assert BaseAnalyzer.is_module_build(build_info) is expected
+
+
+@pytest.mark.parametrize('build_info,expected', [
+    ({'extra': None}, False),
     ({'extra': {'something': []}}, False),
     ({'extra': {'container_koji_task_id': 12345}}, True),
 ])


### PR DESCRIPTION
I spent some time investigating how modules will work. Modules will function essentially like repos. RPMs that are built for modules are regular RPM builds, albeit with weird-looking release strings.

A "module build" like these problematic builds simply produce text metadata files that describe which rpms are in the module. The moral equivalent of running `repocreate`.

I don't think there's anything we care to analyse in "module build" tasks. The interesting stuff is all in the RPM Build. We don't track which repos RPMs go into, and I don't think we care to track with Modules they go into either.

The problem with not tracking modules is that the weird module build versions, like "10.6-1.module+el8+2224+9d92cdc0" for example, will be inserted into the SUPERSEDES chain along with the rest of the normal postgresql versions. Which makes determining which builds are affected by a security vulnerability or similar odd, since the intention of modules is that multiple major versions of a package will be available. For example we have modules for postgresql 7, 8, and 9, and some problem happened to be fixed in the x.1 update of each, the supersedes chain would look something like:

7->7.1->8->8.1->9->9.1
Which goes VULNERABLE->NOT VULNERABLE->VULNERABLE->NOT VULNERABLE->VULNERABLE->NOT VULNERABLE.

However this problem already exists to a lesser extent between Major OS versions and EUS repos, and I think we said we were just going to return all the versions and let people sort it out client-side. So I think that's the most reasonable thing to do here too.

All that to say: I don't think we really care about module builds at all. We just want to make sure the analyser doesn't break. This update will create Build and allow the rest of the Analzyers to run (although they won't find much), but the resulting Build won't have any SourceLocation or Component linked, which I think is fine.