### PR TITLE
Give analyzers the ability to report failures without raising exceptions

### DIFF
--- a/assayist/processor/container_analyzer.py
+++ b/assayist/processor/container_analyzer.py
@@ -9,7 +9,11 @@ class ContainerAnalyzer(Analyzer):
     """Analyzes the parent builds of a specific build."""
 
     def run(self):
-        """Start the container analyzer."""
+        """
+        Start the container analyzer.
+
+        :raises AnalysisFailure: if the analyzer completed with errors
+        """
         build_info = self.read_metadata_file(self.BUILD_FILE)
         build_id = build_info['id']
 

--- a/assayist/processor/container_rpm_analyzer.py
+++ b/assayist/processor/container_rpm_analyzer.py
@@ -11,7 +11,11 @@ class ContainerRPMAnalyzer(Analyzer):
     """Analyze the RPMs in a container image layer."""
 
     def run(self):
-        """Start the container RPM analyzer."""
+        """
+        Start the container RPM analyzer.
+
+        :raises AnalysisFailure: if the analyzer completed with errors
+        """
         build_info = self.read_metadata_file(self.BUILD_FILE)
         build_id = build_info['id']
         if not self.is_container_build(build_info):

--- a/assayist/processor/error.py
+++ b/assayist/processor/error.py
@@ -5,3 +5,9 @@ class BuildSourceNotFound(RuntimeError):
     """Signify that the source of a Koji build couldn't be determined."""
 
     pass
+
+
+class AnalysisFailure(RuntimeError):
+    """Signify that an Analyzer completed its analysis but wasn't completely successful."""
+
+    pass

--- a/assayist/processor/loose_artifact_analyzer.py
+++ b/assayist/processor/loose_artifact_analyzer.py
@@ -32,7 +32,11 @@ class LooseArtifactAnalyzer(Analyzer):
     KOJI_BATCH_SIZE = 10
 
     def run(self):
-        """Start the loose RPM analyzer."""
+        """
+        Start the loose RPM analyzer.
+
+        :raises AnalysisFailure: if the analyzer completed with errors
+        """
         build_info = self.read_metadata_file(self.BUILD_FILE)
         build_id = build_info['id']
 

--- a/assayist/processor/main_analyzer.py
+++ b/assayist/processor/main_analyzer.py
@@ -102,7 +102,11 @@ class MainAnalyzer(Analyzer):
         return component, cversion
 
     def run(self):
-        """Do the actual processing."""
+        """
+        Do the actual processing.
+
+        :raises AnalysisFailure: if the analyzer completed with errors
+        """
         build_info = self.read_metadata_file(self.BUILD_FILE)
         task_info = self.read_metadata_file(self.TASK_FILE)
 

--- a/assayist/processor/post_analyzer.py
+++ b/assayist/processor/post_analyzer.py
@@ -20,7 +20,11 @@ class PostAnalyzer(Analyzer):
     """Performs post-analysis."""
 
     def run(self):
-        """Start the post analyzer."""
+        """
+        Start the post analyzer.
+
+        :raises AnalysisFailure: if the analyzer completed with errors
+        """
         build_info = self.read_metadata_file(self.BUILD_FILE)
         build_id = build_info['id']
 


### PR DESCRIPTION
This is useful for the Go analyzer since it can fail to analyze some of the source code using backvendor, but it should continue the analysis. So now, instead of just failing outright, this PR makes it so that the analyzers can choose to continue but denote to the caller that it wasn't a total success.

Addresses FACTORY-3520