### PR TITLE
FACTORY-3571: Don't error if there is no source url

### DIFF
--- a/scripts/download-unpack-build.py
+++ b/scripts/download-unpack-build.py
@@ -41,16 +41,16 @@ for directory in (output_metadata_dir, output_files_dir, unpacked_archives_dir, 
     if not os.path.isdir(directory):
         os.mkdir(directory)
 
-utils.download_build_data(build_identifier, output_metadata_dir)
-artifacts, build_info = utils.download_build(build_identifier, output_files_dir)
 try:
-    utils.download_source(build_info, output_source_dir)
+    utils.download_build_data(build_identifier, output_metadata_dir)
 except BuildSourceNotFound as e:
     print(e, file=sys.stderr)
     # If the source wasn't found, then just exit the script with an exit code of 3. Then the runner
     # of the script can determine what to do from here.
     sys.exit(3)
 
+artifacts, build_info = utils.download_build(build_identifier, output_files_dir)
+utils.download_source(build_info, output_source_dir)
 utils.unpack_artifacts(artifacts, unpacked_archives_dir)
 
 log.info(f'See the downloaded brew metadata at {output_metadata_dir}')


### PR DESCRIPTION
It appears some builds don't have source urls. I'm surprised by that, but there's not much we can do in that case. We need for there to be a SourceLocation so that we can connect a Component and the Build doesn't appear to be a stub.

1) If there is a component connected with this SL, which there should be in all these cases, then generate a fake url that is unique to this component to connect. That way at least we'll keep all the components / builds that don't have urls connected to each other and only each other.

2) If there is no component, connect it to a completely fake url. If this path is ever followed then all those builds will wind up connected to the one really weird SL, but I can't think of how that would happen.