### PR TITLE
FACTORY-3564: Teach the Analyzers about component alternate_names

### DIFF
--- a/assayist/common/models/source.py
+++ b/assayist/common/models/source.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0+
 
-from neomodel import StringProperty, ArrayProperty, RelationshipFrom, RelationshipTo, ZeroOrOne
+from neomodel import StringProperty, ArrayProperty, RelationshipFrom, RelationshipTo, ZeroOrOne, db
 
 from assayist.common.models.base import AssayistStructuredNode
 
@@ -22,6 +22,67 @@ class Component(AssayistStructuredNode):
 
     # The source locations that provide this component
     source_locations = RelationshipFrom('SourceLocation', 'SOURCE_FOR')
+
+    @staticmethod
+    def get_or_create(*props, **kwargs):
+        """
+        Override the get_or_create builtin to ensure it is not accidentally used.
+
+        :param props: anything you want
+        :param kwargs: anything you want
+        :rtype: RuntimeError
+        """
+        raise RuntimeError("Don't use the get_or_create builtin, instead use our ",
+                           "'get_or_create_singleton' method to ensure alternate names "
+                           "are accounted for.")
+
+    @staticmethod
+    def create_or_update(*props, **kwargs):
+        """
+        Override the get_or_create builtin to ensure it is not accidentally used.
+
+        :param props: anything you want
+        :param kwargs: anything you want
+        :rtype: RuntimeError
+        """
+        raise RuntimeError("Don't use the get_or_create builtin, instead use our ",
+                           "'get_or_create_singleton' method to ensure alternate names "
+                           "are accounted for.")
+
+    @staticmethod
+    def get_or_create_singleton(canonical_namespace, canonical_name, canonical_type):
+        """
+        Get or create a single Component, accounting for possible alternative names.
+
+        Note that this function does not have nearly as much functionality as the builtins
+        it is replacing, nor is it atomic. I had wanted to alias the builtins too in
+        case tests or something really needed them, but I couldn't make that work right.
+        However for our use cases this should be a "good enough" implementation of get_or_create.
+
+        :param str canonical_namespace: The namespace for the Component. Required.
+        :param str canonical_name: The name for the Component. Returned Component's name
+                                   might be different if this matches an alternative_name.
+                                   Required.
+        :param str canonical_type: The type for the Component. Required.
+        :return: The saved component you requested.
+        :rtype: Component
+        """
+        query = """
+        MATCH (c:Component {{canonical_type: "{2}", canonical_namespace: "{0}" }})
+        WHERE c.canonical_name = "{1}" OR "{1}" in c.alternative_names
+        RETURN c
+        """.format(canonical_namespace, canonical_name, canonical_type)
+
+        results, _ = db.cypher_query(query)
+        if results:
+            # There should only be one, because set_component_names de-duplicates as it adds
+            # alternative_names.
+            assert len(results) == 1
+            return Component.inflate(results[0][0])
+
+        return Component(canonical_namespace=canonical_namespace,
+                         canonical_name=canonical_name,
+                         canonical_type=canonical_type).save()
 
 
 class SourceLocation(AssayistStructuredNode):

--- a/assayist/processor/container_go_analyzer.py
+++ b/assayist/processor/container_go_analyzer.py
@@ -161,11 +161,7 @@ class ContainerGoAnalyzer(Analyzer):
         :param str rev: vcs revision
         """
         namespace, name = mod.rsplit('/', 1)  # There must be at least one '/'
-        component = source.Component.get_or_create({
-            'canonical_type': 'golang',
-            'canonical_namespace': namespace,
-            'canonical_name': name})[0]
-
+        component = source.Component.get_or_create_singleton(namespace, name, 'golang')
         upstream = self.create_or_update_source_location("#".join([repo, rev]),
                                                          component,
                                                          ver)

--- a/assayist/processor/main_analyzer.py
+++ b/assayist/processor/main_analyzer.py
@@ -95,10 +95,7 @@ class MainAnalyzer(Analyzer):
         else:
             return None, None
 
-        component = source.Component.get_or_create({
-            'canonical_namespace': cnamespace,
-            'canonical_name': cname,
-            'canonical_type': ctype})[0]
+        component = source.Component.get_or_create_singleton(cnamespace, cname, ctype)
         return component, cversion
 
     def run(self):

--- a/tests/client/test_modify.py
+++ b/tests/client/test_modify.py
@@ -21,11 +21,7 @@ def test_set_component_names_new():
 
 def test_set_component_names_add_alt_names():
     """Test that set_component_names can add alternative names to an existing component."""
-    Component.get_or_create({
-        'canonical_namespace': '',
-        'canonical_name': 'requests',
-        'canonical_type': 'pypi'
-    })[0]
+    Component.get_or_create_singleton('', 'requests', 'pypi')
 
     modify.set_component_names('requests', 'pypi', alternatives=['python-requests'])
 
@@ -37,12 +33,9 @@ def test_set_component_names_add_alt_names():
 
 def test_set_component_names_fix_canonical_name():
     """Test that set_component_names fixes a canonical name."""
-    Component.get_or_create({
-        'canonical_namespace': '',
-        'canonical_name': 'python-requests',
-        'canonical_type': 'pypi',
-        'alternative_names': ['python3-requests']
-    })[0]
+    c = Component.get_or_create_singleton('', 'python-requests', 'pypi')
+    c.alternative_names = ['python3-requests']
+    c.save()
 
     modify.set_component_names('requests', 'pypi', alternatives=['python-requests'])
 
@@ -55,12 +48,9 @@ def test_set_component_names_fix_canonical_name():
 
 def test_set_component_names_fix_canonical_name_no_alt_input():
     """Test that set_component_names fixes a canonical name with alternatives input."""
-    Component.get_or_create({
-        'canonical_namespace': '',
-        'canonical_name': 'python-requests',
-        'canonical_type': 'pypi',
-        'alternative_names': ['requests']
-    })[0]
+    c = Component.get_or_create_singleton('', 'python-requests', 'pypi')
+    c.alternative_names = ['requests']
+    c.save()
 
     modify.set_component_names('requests', 'pypi')
 
@@ -73,21 +63,15 @@ def test_set_component_names_fix_canonical_name_no_alt_input():
 
 def test_set_component_names_merge_multiple_components():
     """Test that set_component_names merges all the matching components."""
-    c1 = Component.get_or_create({
-        'canonical_namespace': '',
-        'canonical_name': 'python-requests',
-        'canonical_type': 'pypi',
-        'alternative_names': ['py-requests', 'requests']
-    })[0]
+    c1 = Component.get_or_create_singleton('', 'python-requests', 'pypi')
+    c1.alternative_names = ['py-requests', 'requests']
+    c1.save()
     sl1 = SourceLocation(url='http://domain.local/python-requests', type_='local').save()
     c1.source_locations.connect(sl1)
 
-    c2 = Component.get_or_create({
-        'canonical_namespace': '',
-        'canonical_name': 'python2-requests',
-        'canonical_type': 'pypi',
-        'alternative_names': ['python3-requests', 'requests']
-    })[0]
+    c2 = Component.get_or_create_singleton('', 'python2-requests', 'pypi')
+    c2.alternative_names = ['python3-requests', 'requests']
+    c2.save()
     sl2 = SourceLocation(url='http://domain.local/python2-requests', type_='local').save()
     c2.source_locations.connect(sl2)
     sl3 = SourceLocation(url='http://domain.local/requests', type_='local').save()

--- a/tests/processor/test_main.py
+++ b/tests/processor/test_main.py
@@ -264,11 +264,7 @@ def test_create_or_update_maven_archive_artifact_from_artifact_info():
 
 def test_create_or_update_source_location():
     """Test the basic function of the create_or_update_source_location function."""
-    rpm_comp = Component.get_or_create({
-        'canonical_namespace': 'a',
-        'canonical_name': 'test',
-        'canonical_type': 'rpm'})[0]
-    rpm_comp.save()
+    rpm_comp = Component.get_or_create_singleton('a', 'test', 'rpm')
     analyzer = main_analyzer.MainAnalyzer()
     url = 'www.whatever.com'
     canonical_version = '0-1-2'
@@ -296,11 +292,7 @@ def test_create_or_update_source_location_bad(m_conditional_connect):
     """Test that create_or_update_source_location rolls back on error."""
     m_conditional_connect.side_effect = ValueError('something broke')
 
-    rpm_comp = Component.get_or_create({
-        'canonical_namespace': 'a',
-        'canonical_name': 'test',
-        'canonical_type': 'rpm'})[0]
-    rpm_comp.save()
+    rpm_comp = Component.get_or_create_singleton('a', 'test', 'rpm')
     analyzer = main_analyzer.MainAnalyzer()
     url = 'www.whatever.com'
     canonical_version = '0-1-3'
@@ -321,11 +313,7 @@ def test_create_or_update_source_location_bad(m_conditional_connect):
 
 def test_supersedes_order_rpm():
     """Test that RPM SourceLocations are associated in the correct order."""
-    rpm_comp = Component.get_or_create({
-        'canonical_namespace': 'another',
-        'canonical_name': 'test',
-        'canonical_type': 'rpm'})[0]
-    rpm_comp.save()
+    rpm_comp = Component.get_or_create_singleton('another', 'test', 'rpm')
 
     URL_BASE = 'www.example.com/some/package#'
     analyzer = main_analyzer.MainAnalyzer()
@@ -352,11 +340,7 @@ def test_supersedes_order_rpm():
 
 def test_supersedes_order_maven():
     """Test that Maven SourceLocations are associated in the correct order."""
-    rpm_comp = Component.get_or_create({
-        'canonical_namespace': 'a',
-        'canonical_name': 'test',
-        'canonical_type': 'java'})[0]
-    rpm_comp.save()
+    rpm_comp = Component.get_or_create_singleton('a', 'test', 'java')
 
     URL_BASE = 'www.example.com/some/package#'
     analyzer = main_analyzer.MainAnalyzer()
@@ -383,11 +367,7 @@ def test_supersedes_order_maven():
 
 def test_supersedes_order_container():
     """Test that conatiner SourceLocations are associated in the correct order."""
-    rpm_comp = Component.get_or_create({
-        'canonical_namespace': 'a',
-        'canonical_name': 'test',
-        'canonical_type': 'docker'})[0]
-    rpm_comp.save()
+    rpm_comp = Component.get_or_create_singleton('a', 'test', 'docker')
 
     URL_BASE = 'www.example.com/some/package#'
     analyzer = main_analyzer.MainAnalyzer()


### PR DESCRIPTION
This update provides a method that has get_or_create-type functionality but is aware of the possibility that the provided name is actually in the alternate_names list instead of the canonical_name property. It is not atomic and only operates on one Component at a time, unlike the built-in get_or_create which can do many at once.

The problem with creating a fully atomic get_or_create substitute is that I couldn't figure out how to make a MERGE query work properly with the WHERE clause requirements we have. WHERE is not a valid keyword on a MERGE query, and I never could figure out how to combine an OPTIONAL MATCH with a MERGE like we would need to. So this is not atomic, however in our use-case I think it should be fine.