### PR TITLE
Add CAP_DAC_OVERRIDE to cpio

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,9 @@ RUN dnf -y install \
   python3-koji \
   python3-neomodel \
   golang \
-  && dnf clean all
+  && dnf clean all \
+  # workaround for unpacking broken rpms in unprivileged container
+  && setcap CAP_DAC_OVERRIDE+ep /usr/bin/cpio
 
 # Tools needed for Go analysis
 RUN go get rsc.io/goversion


### PR DESCRIPTION
There might be some packaging issues which will prevent cpio to create
files in directories with wrong permissions.
e.g. https://github.com/firewalld/firewalld/pull/432

This is a workaround for running in unprivileged container in OpenShift.
Fortunately, CAP_DAC_OVERRIDE available there.

  sh-4.4$ capsh --print
  Current: = cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_audit_write,cap_setfcap+i
  Bounding set =cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_audit_write,cap_setfcap
  Securebits: 00/0x0/1'b0
   secure-noroot: no (unlocked)
   secure-no-suid-fixup: no (unlocked)
   secure-keep-caps: no (unlocked)
  uid=1000120000(???)
  gid=0(root)
  groups=1000120000(???)

I tested and it works :-)