### PR TITLE
Enhance heuristics to determine the source of a build

### DIFF
--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -195,8 +195,8 @@ def get_source_of_build(build_info):
 
     for value in task_request:
         # Check if the value in the task_request is a git URL
-        if isinstance(value, str) and re.match(r'git\+?(https|ssh)?://', value):
-            return value
+        if isinstance(value, str) and re.match(r'git\+?(http[s]?|ssh)?://', value):
+            return re.sub(r'^git\+http', r'http', value)
         # Look for a dictionary in the task_request that may include certain keys that hold the URL
         elif isinstance(value, dict):
             if isinstance(value.get('ksurl'), str):

--- a/tests/processor/test_utils.py
+++ b/tests/processor/test_utils.py
@@ -421,8 +421,13 @@ def test_unpack_artifacts(m_unpack_tar, m_unpack_zip, m_unpack_container_image,
     ),
     (
         {'id': 1, 'source': None, 'task_id': 123},
+        ['red', 'git+http://domain.local/rpms/pkg', 'sox'],
+        'http://domain.local/rpms/pkg'
+    ),
+    (
+        {'id': 1, 'source': None, 'task_id': 123},
         ['red', 'git+https://domain.local/rpms/pkg', 'sox'],
-        'git+https://domain.local/rpms/pkg'
+        'https://domain.local/rpms/pkg'
     ),
     (
         {'id': 1, 'source': None, 'task_id': 123},


### PR DESCRIPTION
It is an enhancement of commit 84c3648d1846dfac8085b8b0bcc72a98b7e79f3f

* do not raise exception for git+http:// (just git+https was allowed)
* do not return prefix "git+" for git+http(s)?
  related to 2d0bf28f1f5abc74ffe84938a8cd57bda6e2d1ed