### PR TITLE
Use source heuristic in download_build

### DIFF
--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -86,6 +86,8 @@ def download_build_data(build_identifier, output_dir='/metadata'):
     :param str/int build_identifier: the string of the builds NVR or the integer of the build ID
     :param str output_dir: the path to download the brew info to
     :raises BuildSourceNotFound: when the source can't be determined
+    :return: build information
+    :rtype: dict
     :raises BuildTypeNotSupported: when the build type is not supported for analysis
     """
     # Import this here to avoid a circular import
@@ -167,25 +169,25 @@ def download_build_data(build_identifier, output_dir='/metadata'):
     if buildroot_components:
         write_file(buildroot_components, output_dir, Analyzer.BUILDROOT_FILE)
 
+    return build
 
-def download_build(build_identifier, output_dir):
+
+def download_build(build, output_dir):
     """
     Download the artifacts associated with a Koji build.
 
-    :param str/int build_identifier: the string of the builds NVR or the integer of the build ID
+    :param dict build: the build information from koji
     :param str output_dir: the path to download the archives to
-    :return: tuple containing a list of downloaded artifacts and the build information
-    :rtype: (list, dict)
+    :return: a list of downloaded artifacts
+    :rtype: list
     """
     # Make sure the Koji command is installed
     assert_command('koji')
     if not os.path.isdir(output_dir):
         raise RuntimeError(f'The passed in directory of "{output_dir}" does not exist')
 
-    session = get_koji_session()
-    build = session.getBuild(build_identifier)
     if not build:
-        raise RuntimeError(f'The Koji build "{build_identifier}" does not exist')
+        raise RuntimeError(f'The Koji build cannot be None')
 
     # There's no API for this, so it's better to just call the CLI directly
     cmd = ['koji', '--profile', config.koji_profile, 'download-build', str(build['id'])]
@@ -218,7 +220,7 @@ def download_build(build_identifier, output_dir):
                 artifacts.append(file_path)
                 log.info(f'Downloaded {os.path.split(file_path)[-1]}')
 
-    return artifacts, build
+    return artifacts
 
 
 def get_source_of_build(build_info):

--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -172,11 +172,11 @@ def download_build_data(build_identifier, output_dir='/metadata'):
     return build
 
 
-def download_build(build, output_dir):
+def download_build(build_info, output_dir):
     """
     Download the artifacts associated with a Koji build.
 
-    :param dict build: the build information from koji
+    :param dict build_info: the build information from koji
     :param str output_dir: the path to download the archives to
     :return: a list of downloaded artifacts
     :rtype: list
@@ -186,11 +186,11 @@ def download_build(build, output_dir):
     if not os.path.isdir(output_dir):
         raise RuntimeError(f'The passed in directory of "{output_dir}" does not exist')
 
-    if not build:
+    if not build_info:
         raise RuntimeError(f'The Koji build cannot be None')
 
     # There's no API for this, so it's better to just call the CLI directly
-    cmd = ['koji', '--profile', config.koji_profile, 'download-build', str(build['id'])]
+    cmd = ['koji', '--profile', config.koji_profile, 'download-build', str(build_info['id'])]
 
     # Because builds may contain artifacts of different types (e.g. RPMs as well as JARs),
     # cycle through all types of artifacts: RPMs (default), Maven archives (--type maven),
@@ -198,7 +198,7 @@ def download_build(build, output_dir):
     # win).
     build_type_opts = ([], ['--type', 'maven'], ['--type', 'image'])
 
-    log.info(f'Downloading build {build["id"]} from Koji')
+    log.info(f'Downloading build {build_info["id"]} from Koji')
     download_prefix = 'Downloading: '
     artifacts = []
 

--- a/scripts/download-unpack-build.py
+++ b/scripts/download-unpack-build.py
@@ -42,7 +42,7 @@ for directory in (output_metadata_dir, output_files_dir, unpacked_archives_dir, 
         os.mkdir(directory)
 
 try:
-    utils.download_build_data(build_identifier, output_metadata_dir)
+    build_info = utils.download_build_data(build_identifier, output_metadata_dir)
 except BuildSourceNotFound as exc:
     print(exc, file=sys.stderr)
     # If the source wasn't found, then just exit the script with an exit code of 3. Then the runner
@@ -54,7 +54,7 @@ except BuildTypeNotSupported as exc:
     # unnecessary data. Exit with 0 so that minimal analysis (creating a Build node) continues.
     sys.exit(0)
 
-artifacts, build_info = utils.download_build(build_identifier, output_files_dir)
+artifacts = utils.download_build(build_info, output_files_dir)
 utils.download_source(build_info, output_source_dir)
 utils.unpack_artifacts(artifacts, unpacked_archives_dir)
 

--- a/tests/processor/test_utils.py
+++ b/tests/processor/test_utils.py
@@ -165,16 +165,9 @@ def test_download_build_unsupported_build_type(m_write_file, m_get_koji_session,
 
 
 @mock.patch('assayist.processor.utils.assert_command')
-@mock.patch('assayist.processor.utils.get_koji_session')
 @mock.patch('subprocess.Popen')
-def test_download_build(m_popen, m_get_koji_session, m_assert_command):
+def test_download_build(m_popen, m_assert_command):
     """Test the download_build function."""
-    m_koji_session = mock.Mock()
-    m_koji_session.getBuild.return_value = {
-        'id': 12345,
-    }
-
-    m_get_koji_session.return_value = m_koji_session
     error = b''
 
     m_process_rpm = mock.Mock()
@@ -203,7 +196,7 @@ def test_download_build(m_popen, m_get_koji_session, m_assert_command):
     process_calls = [m_process_rpm, m_process_maven, m_process_image]
     m_popen.side_effect = process_calls
     with mock.patch('os.path.isdir', return_value=True):
-        rv, _ = utils.download_build(12345, '/some/path')
+        rv = utils.download_build({'task_id': 2, 'id': 1}, '/some/path')
 
     assert rv == [
         '/some/path/resultsdb-2.1.0-2.el7.noarch.rpm',
@@ -212,7 +205,6 @@ def test_download_build(m_popen, m_get_koji_session, m_assert_command):
         '/some/path/com/eng/resultsdb-doc-0.51.0.jar',
     ]
     assert m_popen.call_count == 3
-    m_koji_session.getBuild.assert_called_once_with(12345)
 
 
 @pytest.mark.parametrize('source_url, expected_protocol', [


### PR DESCRIPTION
We use source heuristic in download_build_data and save it info
playground/metadata/buildinfo.json.
    
Later, we got build_info one more time from koji in the function
download_build, but we forgot to use source heuristic there.
    
      Traceback (most recent call last):
        File "/src/scripts/download-unpack-build.py", line 53, in <module>
          utils.download_source(build_info, output_source_dir)
        File "/src/assayist/processor/utils.py", line 235, in download_source
          source_url = re.sub(r'^git\+http', r'http', build_info['source'])
        File "/usr/lib64/python3.6/re.py", line 191, in sub
          return _compile(pattern, flags).sub(repl, string, count)
      TypeError: expected string or bytes-like object
    
      Uncaught exception. Entering post mortem debugging
      Running 'cont' or 'step' will restart the program
      > /usr/lib64/python3.6/re.py(191)sub()
      -> return _compile(pattern, flags).sub(repl, string, count)
      (Pdb) p string
      None
