### PR TITLE
FACTORY-3548: Scan the source for loose artifacts too

### DIFF
--- a/assayist/processor/loose_artifact_analyzer.py
+++ b/assayist/processor/loose_artifact_analyzer.py
@@ -3,7 +3,6 @@
 import glob
 import os
 
-from itertools import zip_longest
 from hashlib import md5
 
 from assayist.common.models import content
@@ -13,7 +12,7 @@ from assayist.processor.logging import log
 
 class LooseArtifactAnalyzer(Analyzer):
     """
-    Analyze RPMs/jars/similar that are embedded in the build artifacts.
+    Analyze RPMs/jars/similar that are embedded in the build artifacts or sources.
 
     RPMs we have to treat differently from other artifact types because Koji treats them
     differently and there is no way to look up an rpm by checksum in the Koji api. So,
@@ -24,6 +23,12 @@ class LooseArtifactAnalyzer(Analyzer):
     and then look them up in koji by checksum. You can accomplish the same thing with
     koji-build-finder, but for our use-case doing it outselves was just as easy and made
     dependency management and debugging a lot simpler.
+
+    The question on what to do with artifacts found embedded in the source dir is a good one.
+    The schema does not currently alow for embedding artifacts in a SourceLocation. Instead
+    the most reasonable (and safe) thing is that is consistent with our existing schema /
+    queries is to assume that artifacts found embedded in the source are in fact embedded
+    in every one of the build archives.
     """
 
     FILE_EXTENSIONS = ['rpm', 'zip', 'tar', 'tar.gz', 'tar.bz2', 'tar.xz', 'rar', 'ear',
@@ -38,123 +43,234 @@ class LooseArtifactAnalyzer(Analyzer):
         :raises AnalysisFailure: if the analyzer completed with errors
         """
         build_info = self.read_metadata_file(self.BUILD_FILE)
-        build_id = build_info['id']
+        self.build_id = build_info['id']
         build_type = build_info['type']
 
         if build_type not in self.SUPPORTED_BUILD_TYPES:
-            log.info(f'Skipping build {build_id} because the build type "{build_type}" '
+            log.info(f'Skipping build {self.build_id} because the build type "{build_type}" '
                      f'is not supported')
             return
 
-        # Dir of all unpacked content to search for RPM files
+        self.batch = []
+
+        # Examine the source for embedded artifacts.
+        source_path = os.path.join(self.input_dir, self.SOURCE_DIR)
+        source_embedded_artifacts = []
+        for loose_artifact in self.files_to_examine(source_path):
+            # If we find it locally don't bother asking Koji about it again.
+            artifact = self.local_lookup(loose_artifact)
+            if artifact:
+                source_embedded_artifacts.append(artifact)
+                continue
+
+            for artifact in self.add_to_and_maybe_execute_batch(loose_artifact, source_path):
+                source_embedded_artifacts.append(artifact)
+
+        # Wrap up any in-progress batch before moving on to the archives.
+        for artifact in self.execute_batch_and_return_artifacts():
+            source_embedded_artifacts.append(artifact)
+
+        # Now examine the build artifacts.
+        for archive, path_to_archive in self.unpacked_archives():
+            # Assume that the artifact being analyzed was created by the main analyzer
+            original_artifact = content.Artifact.nodes.get(filename=archive)
+            # Assume that every artifact found in the source is embedded in every built artifact.
+            for source_artifact in source_embedded_artifacts:
+                original_artifact.embedded_artifacts.connect(source_artifact)
+
+            for loose_artifact in self.files_to_examine(path_to_archive):
+                relative_filepath = os.path.relpath(loose_artifact, path_to_archive)
+
+                try:
+                    artifact = self.local_lookup(loose_artifact)
+                except FileNotFoundError:
+                    # There are two potential causes here, both with symlinks:
+                    # 1) There is a symlink that points to a file in a different
+                    #    layer of the container.
+                    # 2) It was a symlink to something we already analyzed and
+                    #    claimed.
+                    #
+                    # Either way I don't think we really care. If it's already
+                    # claimed then we've already established the link to this
+                    # artifact. If it's referenceing something on a different
+                    # layer of the container then we'll find it when we analyse
+                    # that build (and that's the layer that needs to be respun
+                    # anyway, since that's what contains the actual thing).
+                    # Let's just claim the file and move on.
+                    log.warning(f'Skipping already-claimed symlink in {archive}: '
+                                f'{relative_filepath}')
+                    self.claim_file(path_to_archive, relative_filepath)
+                    continue
+
+                # If we find it locally don't bother asking Koji about it again.
+                if artifact:
+                    self.conditional_connect(original_artifact.embedded_artifacts, artifact)
+                    self.claim_file(path_to_archive, relative_filepath)
+                    continue
+
+                # Add the file to the batch of things to process. If this happens to
+                # trigger a batch execution, handle the resulting Artifacts.
+                for artifact in self.add_to_and_maybe_execute_batch(loose_artifact,
+                                                                    path_to_archive,
+                                                                    claim=True):
+                    self.conditional_connect(original_artifact.embedded_artifacts, artifact)
+
+            # Wrap up any in-progress batch before moving on to the next archive.
+            for artifact in self.execute_batch_and_return_artifacts(claim=True):
+                self.conditional_connect(original_artifact.embedded_artifacts, artifact)
+
+    def local_lookup(self, loose_artifact):
+        """
+        Lookup the given file locally to see if we already know about it.
+
+        Uses sha256 checksum to make that determination.
+
+        :param str loose_artifact: The full path to the file in question.
+        :raises FileNotFoundError: if the file could not be found to checksum.
+        :return: The Artifact that we discovered with a local lookup, or None.
+        :rtype: Artifact or None
+        """
+        sha256_checksum = self.checksum(loose_artifact)
+        try:
+            checksum_node = content.Checksum.nodes.first(checksum=sha256_checksum)
+        except content.Checksum.DoesNotExist:
+            return None
+
+        # According to the schema a checksum can be associated with multiple Artifacts, but
+        # according to reality that doesn't make much sense. Just return the "first one".
+        artifacts = checksum_node.artifacts.all()
+        if artifacts:
+            log.info(f'Artifact already in database: {loose_artifact}')
+            return artifacts[0]
+        else:
+            return None
+
+    def unpacked_archives(self):
+        """
+        Generate name and path to every unpacked archive.
+
+        :return: All (archive_name, path_to_archive) tuples. The path includes archive_name.
+        :rtype: Iterable
+        """
+        # Dir of all unpacked content
         unpacked_content_path = os.path.join(self.input_dir, self.UNPACKED_ARCHIVES_DIR)
+        for archive_type in os.listdir(unpacked_content_path):  # 'rpm', 'container_layer', etc
+            archive_dir = os.path.join(unpacked_content_path, archive_type)
+            for archive in os.listdir(archive_dir):
+                path_to_archive = os.path.join(archive_dir, archive)
+                yield archive, path_to_archive
 
-        for archive_type in os.listdir(unpacked_content_path):  # 'rpm', 'container_layer', 'maven'
-            for archive in os.listdir(os.path.join(unpacked_content_path, archive_type)):
-                path_to_archive = os.path.join(unpacked_content_path, archive_type, archive)
-                # Assume that the artifact being analyzed was created by the main analyzer
-                original_artifact = content.Artifact.nodes.get(filename=archive)
+    def files_to_examine(self, path_to_archive):
+        """
+        Generate the files with extensions we care about.
 
-                for extension in self.FILE_EXTENSIONS:
-                    search_path = os.path.join(path_to_archive, '**/*.' + extension)
-                    for loose_artifact_batch in self.batches(glob.iglob(search_path,
-                                                                        recursive=True)):
-                        self.koji_session.multicall = True
-                        relative_filepath_batch = []
-                        for loose_artifact in loose_artifact_batch:
-                            if not loose_artifact:
-                                # can be None if it's the last batch
-                                continue
-                            relative_filepath = os.path.relpath(loose_artifact, path_to_archive)
-                            # queue up the koji calls
-                            if loose_artifact.endswith('.rpm'):
-                                rpm = os.path.basename(loose_artifact)
-                                log.info(f'Looking up RPM in Koji: {loose_artifact}')
-                                self.koji_session.getRPM(rpm)
-                                relative_filepath_batch.append(relative_filepath)
-                            else:
-                                try:
-                                    md5_checksum = self.checksum(loose_artifact, md5)
-                                except FileNotFoundError:
-                                    # There are two potential causes here, both with symlinks:
-                                    # 1) There is a symlink that points to a file in a different
-                                    #    layer of the container.
-                                    # 2) It was a symlink to something we already analyzed and
-                                    #    claimed.
-                                    #
-                                    # Either way I don't think we really care. If it's already
-                                    # claimed then we've already established the link to this
-                                    # artifact. If it's referenceing something on a different
-                                    # layer of the container then we'll find it when we analyse
-                                    # that build (and that's the layer that needs to be respun
-                                    # anyway, since that's what contains the actual thing).
-                                    # Let's just claim the file and move on.
-                                    log.warning(f'Skipping already-claimed symlink: '
-                                                f'{relative_filepath}')
-                                    self.claim_file(path_to_archive, relative_filepath)
-                                    continue
+        :param str path_to_archive: The absolute path to the archive we are currently examining.
+        :return: All filepaths that we want to examine as potential embedded Artifacts.
+        :rtype: Iterable
+        """
+        for extension in self.FILE_EXTENSIONS:
+            search_path = os.path.join(path_to_archive, '**/*.' + extension)
+            for loose_artifact in glob.iglob(search_path, recursive=True):
+                yield loose_artifact
 
-                                log.info(
-                                    f'Looking up archive in Koji: {md5_checksum}, {loose_artifact}')
-                                self.koji_session.listArchives(checksum=md5_checksum)
-                                relative_filepath_batch.append(relative_filepath)
+    def add_to_and_maybe_execute_batch(self, loose_artifact, path_to_archive, claim=False):
+        """
+        Add the given file to the koji multicall batch.
 
-                        responses = self.koji_session.multiCall()
-                        # Process the individual responses. Responses are returned in the same
-                        # order the calls are added, so we can zip it up to pair back with the
-                        # file path.
-                        for relative_filepath, response in zip(relative_filepath_batch, responses):
-                            is_rpm = relative_filepath.endswith('.rpm')
-                            # If Koji could not find it or there was some other error, log it
-                            # and continue. Response is either a dict if an error, or a list of
-                            # one element if found.
-                            if isinstance(response, dict):
-                                log.error(f'Error received from Koji looking up {relative_filepath}'
-                                          f' embedded in {archive} in build {build_id}. Koji error '
-                                          f'{response["faultString"]}')
-                                continue
+        If the batch is full, execute it and return the resulting Artifacts. Else
+        return empty list.
 
-                            artifact_info = response[0]
-                            if not artifact_info:
-                                log.info(f'Cannot find build for {relative_filepath} embedded in '
-                                         f'{archive} in build {build_id}.')
-                                continue
-
-                            if not is_rpm:
-                                # listArchives returns a list where getRPM returns a hash directly
-                                artifact_info = artifact_info[0]
-
-                            artifact_build_id = artifact_info.get('build_id')
-                            if not artifact_build_id:
-                                log.error(f'Empty build found in Koji for {relative_filepath} '
-                                          f'embedded in {archive} in build {build_id}')
-                                continue
-
-                            log.info(f'Linking discovered embedded artifact {relative_filepath} '
-                                     f'embedded in {archive} in build {build_id}')
-                            artifact_build = content.Build.get_or_create({
-                                'id_': artifact_build_id,
-                                'type_': 'build' if is_rpm else artifact_info['btype'],  # TODO bug!
-                            })[0]
-
-                            if is_rpm:
-                                artifact = self.create_or_update_rpm_artifact_from_rpm_info(
-                                    artifact_info)
-                            else:
-                                artifact = self.create_or_update_archive_artifact_from_archive_info(
-                                    artifact_info)
-
-                            self.conditional_connect(artifact.build, artifact_build)
-                            self.conditional_connect(original_artifact.embedded_artifacts, artifact)
-                            self.claim_file(path_to_archive, relative_filepath)
-
-    def batches(self, iterable):
-        """Return batches of self.KOJI_BATCH_SIZE length items from iterable.
-
-        :param iterable iterable: Anything that can be iterated.
-        :return: A list of KOJI_BATCH_SIZE items, or fewer if iterable is exhausted.
+        :param str loose_artifact: The absolute path to the file in question.
+        :param str path_to_archive: The absolute path to the archive we are currently exporing.
+        :param bool claim: If we should claim the file if we discover an artifact.
+                           Default False.
+        :return: A list of Artifacts created, or empty list.
         :rtype: list
         """
-        # stackoverflow.com/questions/8290397/how-to-split-an-iterable-in-constant-size-chunks
-        args = [iter(iterable)] * self.KOJI_BATCH_SIZE
-        return list(zip_longest(fillvalue=None, *args))
+        if not self.batch:
+            # We're at the beginning of a new batch, initialize the koji multicall session
+            self.koji_session.multicall = True
+
+        relative_filepath = os.path.relpath(loose_artifact, path_to_archive)
+        # queue up the koji calls
+        if loose_artifact.endswith('.rpm'):
+            rpm = os.path.basename(loose_artifact)
+            log.info(f'Looking up RPM in Koji: {loose_artifact}')
+            self.koji_session.getRPM(rpm)
+        else:
+            md5_checksum = self.checksum(loose_artifact, md5)
+
+            log.info(
+                f'Looking up archive in Koji: {md5_checksum}, {loose_artifact}')
+            self.koji_session.listArchives(checksum=md5_checksum)
+
+        self.batch.append((path_to_archive, relative_filepath))
+        if len(self.batch) >= self.KOJI_BATCH_SIZE:
+            return self.execute_batch_and_return_artifacts(claim)
+
+        return []
+
+    def execute_batch_and_return_artifacts(self, claim=False):
+        """
+        Execute the stored Koji batch and return the Artifacts created.
+
+        :param bool claim: If we should claim the file if we discover an artifact.
+                           Default False.
+        :return: A list of Artifacts created.
+        :rtype: list
+        """
+        ret = []
+        if not self.batch:
+            return ret  # gracefully exit early if batch is empty
+        responses = self.koji_session.multiCall()
+        # Process the individual responses. Responses are returned in the same
+        # order the calls are added, so we can zip it up to pair back with the
+        # file path.
+        for (path_to_archive, relative_filepath), response in zip(self.batch, responses):
+            archive = os.path.basename(path_to_archive)
+            is_rpm = relative_filepath.endswith('.rpm')
+            # If Koji could not find it or there was some other error, log it
+            # and continue. Response is either a dict if an error, or a list of
+            # one element if found.
+            if isinstance(response, dict):
+                log.error(f'Error received from Koji looking up {relative_filepath}'
+                          f' embedded in {archive} in build {self.build_id}. Koji error '
+                          f'{response["faultString"]}')
+                continue
+
+            artifact_info = response[0]
+            if not artifact_info:
+                log.info(f'Cannot find build for {relative_filepath} embedded in '
+                         f'{archive} in build {self.build_id}.')
+                continue
+
+            if not is_rpm:
+                # listArchives returns a list where getRPM returns a hash directly
+                artifact_info = artifact_info[0]
+
+            artifact_build_id = artifact_info.get('build_id')
+            if not artifact_build_id:
+                log.error(f'Empty build found in Koji for {relative_filepath} '
+                          f'embedded in {archive} in build {self.build_id}')
+                continue
+
+            log.info(f'Linking discovered embedded artifact {relative_filepath} '
+                     f'embedded in {archive} in build {self.build_id}')
+            artifact_build = content.Build.get_or_create({
+                'id_': artifact_build_id,
+                'type_': 'build' if is_rpm else artifact_info['btype'],  # TODO bug!
+            })[0]
+
+            if is_rpm:
+                artifact = self.create_or_update_rpm_artifact_from_rpm_info(artifact_info)
+            else:
+                artifact = self.create_or_update_archive_artifact_from_archive_info(artifact_info)
+
+            self.conditional_connect(artifact.build, artifact_build)
+            ret.append(artifact)
+            if claim:
+                self.claim_file(path_to_archive, relative_filepath)
+
+        # Clear the processed batch.
+        self.batch = []
+        return ret

--- a/assayist/processor/loose_artifact_analyzer.py
+++ b/assayist/processor/loose_artifact_analyzer.py
@@ -25,7 +25,7 @@ class LooseArtifactAnalyzer(Analyzer):
     dependency management and debugging a lot simpler.
 
     The question on what to do with artifacts found embedded in the source dir is a good one.
-    The schema does not currently alow for embedding artifacts in a SourceLocation. Instead
+    The schema does not currently allow for embedding artifacts in a SourceLocation. Instead
     the most reasonable (and safe) thing is that is consistent with our existing schema /
     queries is to assume that artifacts found embedded in the source are in fact embedded
     in every one of the build archives.
@@ -171,7 +171,8 @@ class LooseArtifactAnalyzer(Analyzer):
         for extension in self.FILE_EXTENSIONS:
             search_path = os.path.join(path_to_archive, '**/*.' + extension)
             for loose_artifact in glob.iglob(search_path, recursive=True):
-                yield loose_artifact
+                if os.path.isfile(loose_artifact):
+                    yield loose_artifact
 
     def add_to_and_maybe_execute_batch(self, loose_artifact, path_to_archive, claim=False):
         """

--- a/tests/processor/test_loose_artifact_analyzer.py
+++ b/tests/processor/test_loose_artifact_analyzer.py
@@ -105,6 +105,7 @@ def test_files_to_examine():
         create_test_archive(True, 'another', 'nested', 'path', 'thing.zip')
         create_test_archive(True, 'another', 'nested', 'path', 'thing.tar.gz')
         create_test_archive(False, 'another', 'nested', 'path', 'thing.csv')
+        create_test_archive(True, 'path', 'with', 'weird', 'dirname.jar', 'thing.kar')
 
         analyzer = LooseArtifactAnalyzer(temp_dir)
         found_files = set()

--- a/tests/processor/test_loose_artifact_analyzer.py
+++ b/tests/processor/test_loose_artifact_analyzer.py
@@ -7,7 +7,7 @@ import mock
 
 from assayist.common.models import content
 from assayist.processor.loose_artifact_analyzer import LooseArtifactAnalyzer
-from tests.factories import BuildFactory, ArtifactFactory
+from tests.factories import BuildFactory, ArtifactFactory, ChecksumFactory
 
 RPM_INFO = {
     'arch': 'noarch',
@@ -20,79 +20,168 @@ RPM_INFO = {
     'version': '1.8.11',
 }
 
-ARCHIVE_INFO = {
-    'build_id': 390982,
-    'type_name': 'pom',
-    'type_id': 3,
-    'checksum': 'b8e892422c0e46cbe8b22d92e7c2517e',
-    'extra': None,
-    'filename': 'geronimo-osgi-registry-1.0.pom',
-    'type_description': 'Maven Project Object Management file',
-    'metadata_only': False,
-    'type_extensions': 'pom',
-    'btype': 'maven',
-    'checksum_type': 0,
-    'btype_id': 2,
-    'buildroot_id': None,
-    'id': 778934,
-    'size': 3320
-}
+
+def archive_info_generator(build_id, archive_id):
+    """Generate a dict of info for an archive."""
+    return {'build_id': build_id,
+            'type_name': 'pom',
+            'type_id': 3,
+            'checksum': 'b8e892422c0e46cbe8b22d92e7c2517e',
+            'extra': None,
+            'filename': 'geronimo-osgi-registry-1.0.pom',
+            'type_description': 'Maven Project Object Management file',
+            'metadata_only': False,
+            'type_extensions': 'pom',
+            'btype': 'maven',
+            'checksum_type': 0,
+            'btype_id': 2,
+            'buildroot_id': None,
+            'id': archive_id,
+            'size': 3320}
 
 
-def test_batches():
-    """Test that the batching function works properly."""
-    analyzer = LooseArtifactAnalyzer()
-    analyzer.KOJI_BATCH_SIZE = 2
-    it = set([1, 2, 3, 4, 5])
-    ret = analyzer.batches(it)
-    assert len(ret) == 3
-    it2 = set()
-    for x, y in ret:
-        it2.add(x)
-        if y:
-            it2.add(y)
-
-    assert it == it2
+ARCHIVE_INFO1 = archive_info_generator(390981, 778931)
+ARCHIVE_INFO2 = archive_info_generator(390982, 778932)
+ARCHIVE_INFO3 = archive_info_generator(390983, 778933)
+ARCHIVE_INFO4 = archive_info_generator(390984, 778934)
+SOURCE_ARCHIVE_INFO = archive_info_generator(390985, 778935)
 
 
+def create_test_file(test_dir, extension, content):
+    """Touch files in the test directory."""
+    x = os.path.join(test_dir, 'test_file.' + extension)
+    with open(x, 'a') as f:
+        f.write(content)
+    return x
+
+
+def test_unpacked_archives():
+    """Test that the unpacked_archives method correctly finds all archives."""
+    expected_paths = set()
+    expected_archives = set()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        def create_test_archive(a_type, name):
+            path = os.path.join(temp_dir, 'unpacked_archives', a_type, name)
+            os.makedirs(path)
+            expected_paths.add(path)
+            expected_archives.add(name)
+
+        create_test_archive('rpm', 'name-1-2-3.noarch.rpm')
+        create_test_archive('rpm', 'name2-1-2-3.noarch.rpm')
+        create_test_archive('container_layer', 'docker-image:sha1234')
+        create_test_archive('container_layer', 'docker-image:sha4321')
+        create_test_archive('maven', 'really-important.jar')
+        create_test_archive('maven', 'really-important-2.jar')
+
+        analyzer = LooseArtifactAnalyzer(temp_dir)
+        found_names = set()
+        found_paths = set()
+        for name, path in analyzer.unpacked_archives():
+            found_names.add(name)
+            found_paths.add(path)
+
+        assert found_names == expected_archives
+        assert found_paths == expected_paths
+
+
+def test_files_to_examine():
+    """Test the files_to_examine method correctly discoveres all files it's supposed to."""
+    expected_files = set()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        def create_test_archive(expected, *args):
+            new_dir = os.path.join(temp_dir, *args[:-1])
+            try:
+                os.makedirs(new_dir)
+            except FileExistsError:
+                pass
+            f = create_test_file(new_dir, args[-1], 'content')
+            if expected:
+                expected_files.add(f)
+
+        create_test_archive(True, 'path', 'to', 'some', 'nested', 'thing.rpm')
+        create_test_archive(True, 'path', 'to', 'some', 'nested', 'thing.jar')
+        create_test_archive(False, 'path', 'to', 'some', 'nested', 'thing.txt')
+        create_test_archive(True, 'another', 'nested', 'path', 'thing.tar')
+        create_test_archive(True, 'another', 'nested', 'path', 'thing.zip')
+        create_test_archive(True, 'another', 'nested', 'path', 'thing.tar.gz')
+        create_test_archive(False, 'another', 'nested', 'path', 'thing.csv')
+
+        analyzer = LooseArtifactAnalyzer(temp_dir)
+        found_files = set()
+        for f in analyzer.files_to_examine(temp_dir):
+            found_files.add(f)
+
+        assert found_files == expected_files
+
+
+def test_local_lookup():
+    """Test the local_lookup function correctly finds Artifacts that already exist."""
+    CONTENT = 'my content'
+    SHA256_SUM = '47a96905708e5470528752169f80e1d8d8b79c599ed35b0979fb9f17e9babfe6'
+
+    checksum_node = ChecksumFactory.create(checksum=SHA256_SUM)
+    artifact_node = ArtifactFactory.create(type_='rpm')
+    artifact_node.checksums.connect(checksum_node)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        jar_file = create_test_file(temp_dir, 'jar', CONTENT)
+        zip_file = create_test_file(temp_dir, 'zip', 'some other content')
+
+        analyzer = LooseArtifactAnalyzer(temp_dir)
+        assert analyzer.local_lookup(jar_file) == artifact_node
+        assert analyzer.local_lookup(zip_file) is None
+
+
+@mock.patch('assayist.processor.loose_artifact_analyzer.LooseArtifactAnalyzer.local_lookup')
 @mock.patch('assayist.processor.base.Analyzer.read_metadata_file')
-def test_rpm_on_container_layer(m_read_metadata_file):
+def test_rpm_on_container_layer(m_read_metadata_file, m_local_lookup):
     """Test the LooseArtifactAnalyzer on an container embedding RPM content."""
     build = BuildFactory.create()
     container = ArtifactFactory.create(type_='container')
     build.artifacts.connect(container)
 
-    m_read_metadata_file.return_value = {'id': 1, 'type': 'buildContainer'}
+    m_read_metadata_file.return_value = {'id': build.id_, 'type': 'buildContainer'}
+    m_local_lookup.return_value = None
 
     m_koji = mock.Mock()
-    m_koji.multiCall.return_value = [[RPM_INFO]]
+    # Return the source artifact first, then the rpm second.
+    # The bracket differences are just a matter of how the getRPM and listArchives
+    # return different types of responses.
+    m_koji.multiCall.side_effect = ([[[SOURCE_ARCHIVE_INFO]]], [[RPM_INFO]])
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = os.path.join(temp_dir, 'source')
+        os.makedirs(source_dir)
         layer_dir = os.path.join(
             temp_dir, 'unpacked_archives', 'container_layer', container.filename)
         test_dir = os.path.join(layer_dir, 'test_dir')
         os.makedirs(test_dir)
 
-        test_file = os.path.join(test_dir, 'test_file.txt')
-        open(test_file, 'a').close()
-
-        rpm_test_file = os.path.join(test_dir, 'test.rpm')
-        open(rpm_test_file, 'a').close()
+        source_artifact = create_test_file(source_dir, 'jar', 'asdf')
+        test_file = create_test_file(test_dir, 'txt', 'dfas')
+        rpm_test_file = create_test_file(test_dir, 'rpm', 'asdfasdf')
 
         analyzer = LooseArtifactAnalyzer(temp_dir)
         analyzer._koji_session = m_koji
         analyzer.run()
 
+        # There's no reason to claim things in the source.
+        assert os.path.exists(source_artifact) is True
+        # Is not a type of file that should be found.
         assert os.path.exists(test_file) is True
+        # Should have been claimed
         assert os.path.exists(rpm_test_file) is False
 
     assert m_read_metadata_file.call_count == 1
+    assert m_koji.listArchives.call_count == 1
     assert m_koji.getRPM.call_count == 1
 
     container_artifact = content.Artifact.nodes.get(type_='container')  # there should be only 1
     loose_rpm_artifact = content.Artifact.nodes.get(archive_id=RPM_INFO['id'])
+    source_artifact = content.Artifact.nodes.get(archive_id=SOURCE_ARCHIVE_INFO['id'])
 
     assert container_artifact.embedded_artifacts.is_connected(loose_rpm_artifact)
+    assert container_artifact.embedded_artifacts.is_connected(source_artifact)
 
     # assert the build was created and connected
     build = content.Build.nodes.get(id_=str(RPM_INFO['build_id']))
@@ -101,56 +190,65 @@ def test_rpm_on_container_layer(m_read_metadata_file):
     assert loose_rpm_artifact.build.is_connected(build)
 
 
+@mock.patch('assayist.processor.loose_artifact_analyzer.LooseArtifactAnalyzer.local_lookup')
 @mock.patch('assayist.processor.base.Analyzer.read_metadata_file')
-def test_archives_on_container_layer(m_read_metadata_file):
+def test_archives_on_container_layer(m_read_metadata_file, m_local_lookup):
     """Test the LooseArtifactAnalyzer on a contanier embedding maven content."""
     build = BuildFactory.create()
     container = ArtifactFactory.create(type_='container')
     build.artifacts.connect(container)
 
-    m_read_metadata_file.return_value = {'id': 1, 'type': 'buildContainer'}
+    m_read_metadata_file.return_value = {'id': build.id_, 'type': 'buildContainer'}
+    m_local_lookup.return_value = None
 
     m_koji = mock.Mock()
-    m_koji.multiCall.return_value = [[[ARCHIVE_INFO]]]
+    # Two distinct calls. Return the source artifact first, then the embedded artifacts second.
+    m_koji.multiCall.side_effect = ([[[SOURCE_ARCHIVE_INFO]]], [[[ARCHIVE_INFO1]],
+                                    [[ARCHIVE_INFO2]], [[ARCHIVE_INFO3]], [[ARCHIVE_INFO4]]])
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = os.path.join(temp_dir, 'source')
+        os.makedirs(source_dir)
         layer_dir = os.path.join(
             temp_dir, 'unpacked_archives', 'container_layer', container.filename)
         test_dir = os.path.join(layer_dir, 'test_dir')
         os.makedirs(test_dir)
 
-        def create_test_file(extension):
-            x = os.path.join(test_dir, 'test_file.' + extension)
-            open(x, 'a').close()
-            return x
-
-        test_file = create_test_file('txt')
-        jar_test_file = create_test_file('jar')
-        tar_test_file = create_test_file('tar')
-        xml_test_file = create_test_file('pom.xml')
-        pom_test_file = create_test_file('pom')
+        source_artifact = create_test_file(source_dir, 'jar', 'some')
+        test_file = create_test_file(test_dir, 'txt', 'distinct')
+        jar_test_file = create_test_file(test_dir, 'jar', 'content')
+        tar_test_file = create_test_file(test_dir, 'tar', 'that')
+        xml_test_file = create_test_file(test_dir, 'pom.xml', 'checksums')
+        pom_test_file = create_test_file(test_dir, 'pom', 'differently')
 
         analyzer = LooseArtifactAnalyzer(temp_dir)
         analyzer._koji_session = m_koji
         analyzer.run()
 
+        # There's no reason to claim things in the source.
+        assert os.path.exists(source_artifact) is True
+        # Is not a type of file that should be found.
         assert os.path.exists(test_file) is True
+        # Should have been claimed
         assert os.path.exists(jar_test_file) is False
         assert os.path.exists(tar_test_file) is False
         assert os.path.exists(xml_test_file) is False
         assert os.path.exists(pom_test_file) is False
 
     assert m_read_metadata_file.call_count == 1
-    assert m_koji.listArchives.call_count == 4
+    assert m_koji.listArchives.call_count == 5
 
     container_artifact = content.Artifact.nodes.get(type_='container')  # there should be only 1
-    # We connected four "files" but since the mock method returned the same archive_info for
-    # each it's okay that there's only one result here.
-    loose_artifact = content.Artifact.nodes.get(archive_id=ARCHIVE_INFO['id'])
-    assert container_artifact.embedded_artifacts.is_connected(loose_artifact)
 
-    # assert the build was created and connected
-    build = content.Build.nodes.get(id_=str(ARCHIVE_INFO['build_id']))
-    assert build.id_ == str(ARCHIVE_INFO['build_id'])
-    assert build.type_ == 'maven'
-    assert loose_artifact.build.is_connected(build)
+    source_artifact = content.Artifact.nodes.get(archive_id=SOURCE_ARCHIVE_INFO['id'])
+    assert container_artifact.embedded_artifacts.is_connected(source_artifact)
+
+    for ARCHIVE_INFO in (ARCHIVE_INFO1, ARCHIVE_INFO2, ARCHIVE_INFO3, ARCHIVE_INFO4):
+        loose_artifact = content.Artifact.nodes.get(archive_id=ARCHIVE_INFO['id'])
+        assert container_artifact.embedded_artifacts.is_connected(loose_artifact)
+
+        # assert the build was created and connected
+        build = content.Build.nodes.get(id_=str(ARCHIVE_INFO['build_id']))
+        assert build.id_ == str(ARCHIVE_INFO['build_id'])
+        assert build.type_ == 'maven'
+        assert loose_artifact.build.is_connected(build)


### PR DESCRIPTION
This update teaches the LooseArtifactAnalyzer to look in the source dir for jars and rpms and whatever too.

If it finds any it will associate each "embedded source artifact" with every one of the build's output artifacts. That way our existing schema / queries continue to work. It's slightly pessimistic, pom files for example don't really embed the source artifacts. But better that then missing things.

I have also taken the opportunity to:
 * Implement local neo lookups before we try to call out to koji.
 * Refactored the deeply nested loops into smaller logical generators.
 * Refactored the main logic into utility methods so that it can be reused for the source analysis.
