### PR TITLE
Allow to use relative paths for scripts

### DIFF
--- a/assayist/processor/container_go_analyzer.py
+++ b/assayist/processor/container_go_analyzer.py
@@ -193,7 +193,7 @@ class ContainerGoAnalyzer(Analyzer):
 
             cmd = [self.BACKVENDOR] + options + [srcdir]
             log.info(f'Running {cmd}')
-            bv = subprocess.Popen(cmd, cwd=srcdir, universal_newlines=True,
+            bv = subprocess.Popen(cmd, universal_newlines=True,
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
 

--- a/assayist/processor/utils.py
+++ b/assayist/processor/utils.py
@@ -312,7 +312,7 @@ def download_source(build_info, output_dir, sources_cmd=None):
     log.info(f'Cloning source for {build_info["id"]}')
 
     cmd = ['git', 'clone', url, output_dir]
-    process = subprocess.Popen(cmd, cwd=output_dir,
+    process = subprocess.Popen(cmd,
                                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
     _, error_output = process.communicate()

--- a/tests/processor/test_utils.py
+++ b/tests/processor/test_utils.py
@@ -268,7 +268,7 @@ def test_download_source(m_popen, m_assert_command):
 
     m_popen.assert_has_calls([
         mock.call(['git', 'clone', 'git://pkgs.com/containers/rsyslog', '/some/path'],
-                  cwd='/some/path', stdout=subprocess.DEVNULL, stderr=subprocess.PIPE),
+                  stdout=subprocess.DEVNULL, stderr=subprocess.PIPE),
         mock.call().communicate(),
         mock.call(['git', 'reset', '--hard', '4a4109c3e85908b6899b1aa291570f7c7b5a0cb5'],
                   cwd='/some/path', stdout=subprocess.DEVNULL, stderr=subprocess.PIPE),


### PR DESCRIPTION
git clone use the latest argument for directory where a repo shoudl be cloned.
    
    bash-4.4$ mkdir -p my/playground/with/relative/path
    bash-4.4$ download-unpack-build.py --output-dir my/playground/with/relative/path 797175
    Downloading build 797175 from Koji
    Downloaded docker-image-sha256:39730a159476a9215492e8e340553677b0c970ec970d273abfa180727860bd88.x86_64.tar.gz
    Cloning source for 797175
    Traceback (most recent call last):
      File "/src/scripts/download-unpack-build.py", line 63, in <module>
        utils.download_source(build_info, output_source_dir)
      File "/src/assayist/processor/utils.py", line 308, in download_source
        raise RuntimeError(f'The command "{" ".join(cmd)}" failed with: {error_output}')
    RuntimeError: The command "git reset --hard c217566a3efe1b33f9aa235b9e50052551c236b5" failed with: fatal: not a git repository (or any of the parent directories): .git
    
    bash-4.4$ ls -l my/playground/with/relative/path/source/
    total 0
    drwxr-xr-x. 3 1000120000 root 24 Nov 29 14:50 my


    Traceback (most recent call last):
      File "/src/assayist/processor/container_go_analyzer.py", line 86, in run
        self._process_git_source(source_location, srcdir)
      File "/src/assayist/processor/container_go_analyzer.py", line 138, in _process_git_source
        excludes=self.DIST_GIT_EXCLUDES)
      File "/src/assayist/processor/container_go_analyzer.py", line 233, in _process_source_code
        excludes=excludes)
      File "/src/assayist/processor/container_go_analyzer.py", line 204, in _run_backvendor
        raise RuntimeError(f'The command "{" ".join(cmd)}" failed with: {stderr}')
    RuntimeError: The command "backvendor -debug -x -template       {{.Ver}}        {{.Repo}}       {{.Rev}} -exclude-from /tmp/tmpmu6d53xu my/playground/with/relative/path/source" failed  with: 2018/11/29 14:55:41 lstat /var/tmp/my/playground/with/relative/path/source/my/playground/with/relative/path/source: no such file or directory
    
    bash-4.4$ ls -l my/playground/with/relative/path/source/my/playground/with/relative/path/source/.git
    total 24
    -rw-r--r--. 1 1000120000 root   23 Nov 29 14:50 HEAD
    drwxr-xr-x. 2 1000120000 root    6 Nov 29 14:50 branches
    -rw-r--r--. 1 1000120000 root  272 Nov 29 14:50 config
    -rw-r--r--. 1 1000120000 root   73 Nov 29 14:50 description
    drwxr-xr-x. 2 1000120000 root 4096 Nov 29 14:50 hooks
    -rw-r--r--. 1 1000120000 root  217 Nov 29 14:50 index
    drwxr-xr-x. 2 1000120000 root   21 Nov 29 14:50 info
    drwxr-xr-x. 3 1000120000 root   30 Nov 29 14:50 logs
    drwxr-xr-x. 4 1000120000 root   30 Nov 29 14:50 objects
    -rw-r--r--. 1 1000120000 root  742 Nov 29 14:50 packed-refs
    drwxr-xr-x. 5 1000120000 root   46 Nov 29 14:50 refs